### PR TITLE
Panel: Systemd service file installation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,11 +28,15 @@ cxx.get_supported_arguments([
 language : 'cpp')
 add_global_arguments('-Wno-psabi', language : ['c', 'cpp'])
 
-systemd_system_unit_dir = systemd.get_pkgconfig_variable(
-    'systemdsystemunitdir'
-)
+systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
 
-configure_file(input: 'com.ibm.panel.service',
+service_file = 'service_files/com.ibm.panel.service'
+
+if get_option('system-vpd-dependency').enabled()
+ service_file = 'service_files/ibm.panel.system.vpd.dependent.service'
+endif
+
+configure_file(input: service_file,
                output: 'com.ibm.panel.service',
                install_dir: systemd_system_unit_dir,
                copy: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('tests', type: 'feature', value: 'enabled', description: 'Build tests.',)
+option('system-vpd-dependency', type: 'feature', description: 'Enable/disable system vpd dependency.', value: 'disabled')

--- a/service_files/com.ibm.panel.service
+++ b/service_files/com.ibm.panel.service
@@ -1,8 +1,10 @@
 [Unit]
-Description=Application to interact with the IBM Operator Panel
+Description=IBM operator panel application.
 StopWhenUnneeded=false
 
 [Service]
+BusName=com.ibm.PanelApp
+Type=dbus
 Restart=always
 RestartSec=5
 ExecStart=/usr/bin/ibm-panel

--- a/service_files/ibm.panel.system.vpd.dependent.service
+++ b/service_files/ibm.panel.system.vpd.dependent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=IBM operator panel application.
+StopWhenUnneeded=false
+Requires=system-vpd.service
+After=system-vpd.service
+
+[Service]
+BusName=com.ibm.PanelApp
+Type=dbus
+Restart=always
+RestartSec=5
+ExecStart=/usr/bin/ibm-panel
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Install systemd service file based on the feature flag
"system-vpd-dependency".
Feature flag controls whether or not the panel application
requires system-vpd.service to run before its execution.

When the flag is enabled "ibm.panel.system.vpd.dependent.service" file is
installed into systemd system unit directory. Otherwise the
default "com.ibm.panel.service" is installed.

Test:
Tested on rainier and witherspoon.
Right service file is picked up based on the MACHINE type
given by the panel recipe. The executables are installed
in the bin directory and working as expected.

Test result:
root@rain147bmc-Y232UF09N008:~# systemctl status com.ibm.panel.service
● com.ibm.panel.service - Application to interact with the IBM Operator Panel for P10 BMC machines.
   Loaded: loaded (/lib/systemd/system/com.ibm.panel.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2021-07-21 09:52:23 UTC; 25s ago
  Main PID: 499 (ibm-panel)
   CGroup: /system.slice/com.ibm.panel.service
       └─499 /usr/bin/ibm-panel

Jul 21 09:52:21 rain147bmc-Y232UF09N008 systemd[1]: Starting Application to interact with the IBM Operator Panel for P10 BMC machines....
Jul 21 09:52:22 rain147bmc-Y232UF09N008 ibm-panel[499]: Success opening and accessing the device path: /dev/i2c-7
Jul 21 09:52:22 rain147bmc-Y232UF09N008 ibm-panel[499]: Success opening and accessing the device path: /dev/i2c-3
Jul 21 09:52:22 rain147bmc-Y232UF09N008 ibm-panel[499]: Transport key is set to 1
Jul 21 09:52:22 rain147bmc-Y232UF09N008 ibm-panel[499]: Transport key is set to 0
Jul 21 09:52:23 rain147bmc-Y232UF09N008 systemd[1]: Started Application to interact with the IBM Operator Panel for P10 BMC machines..
Jul 21 09:52:24 rain147bmc-Y232UF09N008 ibm-panel[499]: Transport key is set to 1
root@rain147bmc-Y232UF09N008:~#

Change-Id: I88f413e009e12adbfdbf12bba813f66b65602c32
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>