### PR TITLE
Implementation of functionality 01

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -21,7 +21,10 @@ class Executor
     /* Destructor */
     ~Executor() = default;
 
-    /* Constructor */
+    /**
+     * @brief Constructor
+     * @param[in] transport - Pointer to transport class.
+     */
     Executor(std::shared_ptr<Transport> transportObj) :
         transportObj(transportObj)
     {
@@ -46,6 +49,19 @@ class Executor
      * @brief An api to execute functionality 20
      */
     void execute20();
+
+    /**
+     * @brief An api to execute functionality 01.
+     */
+    void execute01();
+
+    /**
+     * @brief An api of check if OS IPL type is enabled.
+     * It is a helper function for functionality 01. Display needs to be
+     * modified depending upon if OS IPL type is enabled or disabled.
+     * @return OS IPL type enabled/disbaled.
+     */
+    bool isOSIPLTypeEnabled() const;
 
     /*Transport class object*/
     std::shared_ptr<Transport> transportObj;

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "executor.hpp"
 #include "transport.hpp"
 #include "types.hpp"
 
@@ -16,8 +17,8 @@ namespace manager
 /** @class PanelStateManager
  *  @brief Class to implement state handler for Op-Panel.
  * It will hold Op-Panel state information.
- * State of an Op-Panel indicates the current functionality at which the panel
- * is.
+ * State of an Op-Panel indicates the current functionality at which the
+ * panel is.
  */
 class PanelStateManager
 {
@@ -58,8 +59,8 @@ class PanelStateManager
 
     /**
      * @brief Api to process button event.
-     * This api will be called in case of any button event, will process and set
-     * the state of panel accordingly.
+     * This api will be called in case of any button event, will process and
+     * set the state of panel accordingly.
      * @param[in] button - button event.
      */
     void processPanelButtonEvent(const panel::types::ButtonEvent& button);
@@ -87,8 +88,8 @@ class PanelStateManager
   private:
     /**
      * @brief An Api to set the initial state of PanelState class.
-     * It will set the initial state, substate and other class members to their
-     * initial values respectievely.
+     * It will set the initial state, substate and other class members to
+     * their initial values respectively.
      */
     void initPanelState();
 
@@ -157,17 +158,17 @@ class PanelStateManager
     // A list of functions provided by the panel.
     std::vector<PanelFunctionality> panelFunctions;
 
-    // To store current state of Op-Panel. This will store the index of vector
-    // panelFunctions. Fetch function number at that index to get the current
-    // active functionality.
+    // To store current state of Op-Panel. This will store the index of
+    // vector panelFunctions. Fetch function number at that index to get the
+    // current active functionality.
     uint8_t panelCurState;
 
     // To store substate's state. In case of nested substate, every index
     // refer to the level of substate we are at.
     panel::types::FunctionalityList panelCurSubStates;
 
-    // A variable to keep track if sub range is active. Required to decide if we
-    // need to loop in subrange or not.
+    // A variable to keep track if sub range is active. Required to decide
+    // if we need to loop in subrange or not.
     bool isSubrangeActive = false;
 
     // Hold information if state machine is in enabled state or not.
@@ -181,6 +182,8 @@ class PanelStateManager
     /** The current active sub level of function 2 */
     uint8_t levelToOperate = 0;
 
+    /*shared pointer to executor object*/
+    std::shared_ptr<panel::Executor> funcExecutor;
 }; // class PanelStateManager
 
 } // namespace manager

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -20,6 +20,27 @@ using PanelDataTuple = std::tuple<std::string, uint8_t, std::string>;
 using PanelDataMap = std::unordered_map<std::string, PanelDataTuple>;
 using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 
+/*baseBIOSTable reference
+map{attributeName,struct{attributeType,readonlyStatus,displayname,
+              description,menuPath,current,default,
+              array{struct{optionstring,optionvalue}}}}
+*/
+using BiosBaseTableItem = std::pair<
+    std::string,
+    std::tuple<
+        std::string, bool, std::string, std::string, std::string,
+        std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
+        std::vector<
+            std::tuple<std::string, std::variant<int64_t, std::string>>>>>;
+using BiosBaseTable = std::vector<BiosBaseTableItem>;
+
+/* SystemParameterValues reference
+ std::tuple<os_ipl_type, system_operating_mode, hmc_managed, fw_boot_side,
+ hyp_switch>
+ */
+using SystemParameterValues =
+    std::tuple<std::string, std::string, std::string, std::string, std::string>;
+
 enum ButtonEvent
 {
     INCREMENT,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -58,5 +58,13 @@ std::string binaryToHexString(const panel::types::Binary& val);
  */
 void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
                             std::shared_ptr<panel::Transport> transportObj);
+
+/**
+ * @brief An api to read initial values of OS IPL types, System operating
+ * mode, firmware IPL type, Hypervisor type and HMC indicator.
+ * @return - Values of required system parameters.
+ */
+types::SystemParameterValues readSystemParameters();
+
 } // namespace utils
 } // namespace panel

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -190,6 +190,9 @@ void PanelStateManager::initPanelState()
     panelCurSubStates.push_back(StateType::INITIAL_STATE);
     panelCurSubStates.push_back(StateType::INVALID_STATE);
     panelCurSubStates.push_back(StateType::INVALID_STATE);
+
+    // create executorclass
+    funcExecutor = std::make_shared<panel::Executor>(transport);
 }
 
 std::tuple<panel::types::FunctionNumber, panel::types::FunctionNumber>
@@ -464,7 +467,10 @@ void PanelStateManager::executeState()
     {
         // set this anyhow in case we are coming from debounce SRC state.
         panelCurSubStates.at(0) = StateType::INITIAL_STATE;
-        std::cout << "Execute method Directly" << std::endl;
+        std::cout << "Execute method" << std::endl;
+
+        funcExecutor->executeFunction(
+            panelFunctions.at(panelCurState).functionNumber, panelCurSubStates);
     }
 
     // perform what ever operations needs to be done here, execute does not

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,5 +33,79 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
     // command to scroll both the lines towards right, if the lines exceeds
     // 16characters.
 }
+
+types::SystemParameterValues readSystemParameters()
+{
+    auto retVal = readBusProperty<std::variant<types::BiosBaseTable>>(
+        "xyz.openbmc_project.BIOSConfigManager",
+        "/xyz/openbmc_project/bios_config/manager",
+        "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
+
+    const auto baseBiosTable = std::get_if<types::BiosBaseTable>(&retVal);
+
+    // system parameters to be read from BIOS table
+    std::string OSBootType{};
+    std::string systemOperatingMode{};
+    std::string HMCManaged{};
+    std::string FWIPLType{};
+    std::string hypType{};
+
+    if (baseBiosTable != nullptr)
+    {
+        for (const types::BiosBaseTableItem& item : *baseBiosTable)
+        {
+            const auto attributeName = std::get<0>(item);
+            const auto attrValue = std::get<5>(std::get<1>(item));
+            const auto val = std::get_if<std::string>(&attrValue);
+
+            if (val != nullptr)
+            {
+                // TODO: How to get the information from PLDM if IPL type is
+                // enabled to be displayed. Based on that execution of
+                // function 01 needs to be updated to display this data.
+                // Currently it is disabled in the code explicitly.
+                if (attributeName == "pvm_os_boot_type")
+                {
+                    OSBootType = *val;
+                }
+                // TODO: Now this will be combination of (Power restore policy,
+                // AutomaticRetryConfig and StopBootOnFault).
+                else if (attributeName == "pvm_system_operating_mode")
+                {
+                    systemOperatingMode = *val;
+                }
+                else if (attributeName == "pvm_hmc_managed")
+                {
+                    HMCManaged = *val;
+                }
+                // TODO: needs to be updated. Now phyp does not use P/T.
+                // BIOS table will not be used for this. Will be stored at the
+                // panel end.
+                // Have to come up woth new terminology. BMC does not
+                // have P/T boot side.
+                // To Check: When user updates the value to
+                // backup image using function 02 if the display of function 01
+                // does not changes accordingly then we do not need to show this
+                // at all in function 01.
+                else if (attributeName == "pvm_fw_boot_side")
+                {
+                    FWIPLType = *val;
+                }
+                else if (attributeName == "hb_hyp_switch")
+                {
+                    hypType = *val;
+                }
+            }
+        }
+    }
+    else
+    {
+        std::cerr << "Failed to read BIOS base table" << std::endl;
+    }
+
+    return std::make_tuple(OSBootType, systemOperatingMode, HMCManaged,
+                           FWIPLType, hypType);
+}
+
 } // namespace utils
 } // namespace panel


### PR DESCRIPTION
This commit reads system parameter like OSIPLType, systemOperatingMode,
HMCManaged, fwIPLType, hypervisor type over Dbus.

Some of the use case of reading these values are:
a) These values are required to create the output to be displayed on
LCD display with respect to execution of functionality 01 of Op-panel.

b) These values are also required to set the initial state of Op-panel
state manager when functionality 02 is entered.

Sample output when not HMC managed:
L1 : 01  D  N    PVM
L2 :             T

Change-Id: I5df2c76016cdb294ffb0f12e9b1821096168871d
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>