### PR TITLE
Remove "panel" namespace prefix

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -29,7 +29,7 @@ class PanelPresence
      */
     PanelPresence(std::string& objPath,
                   std::shared_ptr<sdbusplus::asio::connection> conn,
-                  std::shared_ptr<panel::Transport> transport) :
+                  std::shared_ptr<Transport> transport) :
         objectPath(objPath),
         conn(conn), transport(transport)
     {
@@ -44,7 +44,7 @@ class PanelPresence
   private:
     std::string objectPath;
     std::shared_ptr<sdbusplus::asio::connection> conn;
-    std::shared_ptr<panel::Transport> transport;
+    std::shared_ptr<Transport> transport;
 
     /** @brief Read panel's "Present" property and set the transport key.
      * @param[in] msg - pointer to the msg sent by the PropertiesChanged signal.

--- a/include/button_handler.hpp
+++ b/include/button_handler.hpp
@@ -43,8 +43,8 @@ class ButtonHandler
      */
     ButtonHandler(
         const std::string& path, std::shared_ptr<boost::asio::io_context>& io,
-        std::shared_ptr<panel::Transport> transport,
-        std::shared_ptr<panel::state::manager::PanelStateManager> stateManager);
+        std::shared_ptr<Transport> transport,
+        std::shared_ptr<state::manager::PanelStateManager> stateManager);
 
   private:
     /** @brief Api to perform async read operation on the device path.
@@ -72,10 +72,10 @@ class ButtonHandler
     std::vector<input_event> ipEvent;
 
     /* transport object required for calling transport functions */
-    std::shared_ptr<panel::Transport> transport;
+    std::shared_ptr<Transport> transport;
 
     /* state manager object to call increment/decrement/execute functions */
-    std::shared_ptr<panel::state::manager::PanelStateManager> stateManager;
+    std::shared_ptr<state::manager::PanelStateManager> stateManager;
 
     /* file descriptor */
     int fd = -1;

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -45,7 +45,7 @@ class PanelStateManager
     /**
      * @brief Api to get state and sub state info of panel.
      * */
-    std::tuple<panel::types::FunctionNumber, panel::types::FunctionNumber>
+    std::tuple<types::FunctionNumber, types::FunctionNumber>
         getPanelCurrentStateInfo() const;
 
     /**
@@ -55,7 +55,7 @@ class PanelStateManager
      * corresponding to a functionality.
      * */
     void enableFunctonality(
-        const panel::types::FunctionalityList& listOfFunctionalities);
+        const types::FunctionalityList& listOfFunctionalities);
 
     /**
      * @brief Api to process button event.
@@ -63,7 +63,7 @@ class PanelStateManager
      * set the state of panel accordingly.
      * @param[in] button - button event.
      */
-    void processPanelButtonEvent(const panel::types::ButtonEvent& button);
+    void processPanelButtonEvent(const types::ButtonEvent& button);
 
     /**
      * @brief Api to set state of Panel state handler altogether.
@@ -79,7 +79,7 @@ class PanelStateManager
      * @brief Constructor.
      * @param[in] transport - transport object to call transport functions.
      */
-    PanelStateManager(std::shared_ptr<panel::Transport> transport) :
+    PanelStateManager(std::shared_ptr<Transport> transport) :
         transport(transport)
     {
         initPanelState();
@@ -113,7 +113,7 @@ class PanelStateManager
      * mode.
      * @param[in] button - button event.
      */
-    void setIPLParameters(const panel::types::ButtonEvent& button);
+    void setIPLParameters(const types::ButtonEvent& button);
 
     /** @brief API to create the display string. */
     void createDisplayString() const;
@@ -143,7 +143,7 @@ class PanelStateManager
     struct PanelFunctionality
     {
         // serial number of the function.
-        panel::types::FunctionNumber functionNumber = 0;
+        types::FunctionNumber functionNumber = 0;
 
         // true is enabled false is disabled.
         bool functionActiveState = false;
@@ -152,7 +152,7 @@ class PanelStateManager
         std::string debouceSrc{};
 
         // Upper range in sub function list.
-        panel::types::FunctionNumber subFunctionUpperRange;
+        types::FunctionNumber subFunctionUpperRange;
     };
 
     // A list of functions provided by the panel.
@@ -165,7 +165,7 @@ class PanelStateManager
 
     // To store substate's state. In case of nested substate, every index
     // refer to the level of substate we are at.
-    panel::types::FunctionalityList panelCurSubStates;
+    types::FunctionalityList panelCurSubStates;
 
     // A variable to keep track if sub range is active. Required to decide
     // if we need to loop in subrange or not.
@@ -177,13 +177,13 @@ class PanelStateManager
     const std::vector<std::vector<std::string>> functionality02 = {
         {{"A", "B", "C", "D"}, {"M", "N"}, {"P", "T"}}};
 
-    std::shared_ptr<panel::Transport> transport;
+    std::shared_ptr<Transport> transport;
 
     /** The current active sub level of function 2 */
     uint8_t levelToOperate = 0;
 
     /*shared pointer to executor object*/
-    std::shared_ptr<panel::Executor> funcExecutor;
+    std::shared_ptr<Executor> funcExecutor;
 }; // class PanelStateManager
 
 } // namespace manager

--- a/include/transport.hpp
+++ b/include/transport.hpp
@@ -23,7 +23,7 @@ class Transport
      * and device address based on the system type.
      */
     Transport(const std::string& devPath, const uint8_t& devAddr,
-              const panel::types::PanelType& type) :
+              const types::PanelType& type) :
         devPath(devPath),
         devAddress(devAddr), panelType(type)
     {
@@ -47,7 +47,7 @@ class Transport
      * controller.
      * @param[in] buffer - data that needs to be sent to the panel.
      */
-    void panelI2CWrite(const panel::types::Binary& buffer) const;
+    void panelI2CWrite(const types::Binary& buffer) const;
 
     /** @brief Method to set the transport key
      * The transportKey boolean tells if the panel i2c bus is ready to use or
@@ -86,7 +86,7 @@ class Transport
     bool transportKey = false;
 
     /** @brief Panel type (base/lcd) */
-    const panel::types::PanelType panelType;
+    const types::PanelType panelType;
 
     /** @brief Establish panel i2c connection
      * This api establishes the i2c bus connection to the panel micro

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -43,7 +43,7 @@ T readBusProperty(const std::string& service, const std::string& object,
  * @param[in] val - byte vector that needs conversion
  * @return hex string
  */
-std::string binaryToHexString(const panel::types::Binary& val);
+std::string binaryToHexString(const types::Binary& val);
 
 /** @brief Display on panel using transport class api.
  *
@@ -57,7 +57,7 @@ std::string binaryToHexString(const panel::types::Binary& val);
  * method.
  */
 void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
-                            std::shared_ptr<panel::Transport> transport);
+                            std::shared_ptr<Transport> transport);
 
 /**
  * @brief An api to read initial values of OS IPL types, System operating

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -11,7 +11,7 @@ void PanelPresence::readPresentProperty(sdbusplus::message::message& msg)
         std::cerr << "\n Error in reading panel presence signal " << std::endl;
     }
     std::string object;
-    panel::types::ItemInterfaceMap invItemMap;
+    types::ItemInterfaceMap invItemMap;
     msg.read(object, invItemMap);
     const auto itr = invItemMap.find("Present");
     if (itr != invItemMap.end())
@@ -33,7 +33,7 @@ void PanelPresence::listenPanelPresence()
         std::make_shared<sdbusplus::bus::match::match>(
             *conn,
             sdbusplus::bus::match::rules::propertiesChanged(
-                objectPath, panel::constants::itemInterface),
+                objectPath, constants::itemInterface),
             [this](sdbusplus::message::message& msg) {
                 readPresentProperty(msg);
             });

--- a/src/button_handler.cpp
+++ b/src/button_handler.cpp
@@ -12,8 +12,8 @@ namespace panel
 
 ButtonHandler::ButtonHandler(
     const std::string& path, std::shared_ptr<boost::asio::io_context>& io,
-    std::shared_ptr<panel::Transport> transport,
-    std::shared_ptr<panel::state::manager::PanelStateManager> stateManager) :
+    std::shared_ptr<Transport> transport,
+    std::shared_ptr<state::manager::PanelStateManager> stateManager) :
     devicePath(path),
     io(io), transport(transport), stateManager(stateManager)
 {
@@ -80,17 +80,17 @@ void ButtonHandler::processInputEvent(const boost::system::error_code& ec,
             {
                 case BTN_NORTH:
                     stateManager->processPanelButtonEvent(
-                        panel::types::ButtonEvent::INCREMENT);
+                        types::ButtonEvent::INCREMENT);
                     break;
 
                 case BTN_SOUTH:
                     stateManager->processPanelButtonEvent(
-                        panel::types::ButtonEvent::DECREMENT);
+                        types::ButtonEvent::DECREMENT);
                     break;
 
                 case BTN_SELECT:
                     stateManager->processPanelButtonEvent(
-                        panel::types::ButtonEvent::EXECUTE);
+                        types::ButtonEvent::EXECUTE);
                     break;
 
                 default: /* unknown button event*/

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -82,7 +82,7 @@ bool Executor::isOSIPLTypeEnabled() const
 
 void Executor::execute01()
 {
-    const auto sysValues = panel::utils::readSystemParameters();
+    const auto sysValues = utils::readSystemParameters();
 
     if (!std::get<0>(sysValues).empty() && !std::get<1>(sysValues).empty() &&
         !std::get<2>(sysValues).empty() && !std::get<3>(sysValues).empty() &&

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -24,13 +24,13 @@ static constexpr auto FUNCTION_02 = 2;
 // structure defines fincttionaliy attributes.
 struct FunctionalityAttributes
 {
-    panel::types::FunctionNumber funcNumber;
+    types::FunctionNumber funcNumber;
     // Any function number not dependent on the state of the machine or any
     // other element will be enabled by default.
     bool defaultEnabled;
     bool isDebounceRequired;
     std::string debounceSrcValue;
-    panel::types::FunctionNumber subRangeEndPoint;
+    types::FunctionNumber subRangeEndPoint;
 };
 
 // This can be moved to a common file in case this information needs to be
@@ -72,7 +72,7 @@ std::vector<FunctionalityAttributes> functionalityList = {
     {70, false, false, "NONE", StateType::INITIAL_STATE}};
 
 void PanelStateManager::enableFunctonality(
-    const panel::types::FunctionalityList& listOfFunctionalities)
+    const types::FunctionalityList& listOfFunctionalities)
 {
     for (const auto& functionNumber : listOfFunctionalities)
     {
@@ -139,28 +139,28 @@ void PanelStateManager::printPanelStates()
 }
 
 void PanelStateManager::processPanelButtonEvent(
-    const panel::types::ButtonEvent& button)
+    const types::ButtonEvent& button)
 {
     // In case panel is in DEBOUCNE_SRC_STATE, and next button is increment
     // or decrement, it should come out of DEBOUCNE_SRC_STATE
     if (panelCurSubStates.at(0) == StateType::DEBOUCNE_SRC_STATE &&
-        (button == panel::types::ButtonEvent::INCREMENT ||
-         button == panel::types::ButtonEvent::DECREMENT))
+        (button == types::ButtonEvent::INCREMENT ||
+         button == types::ButtonEvent::DECREMENT))
     {
         panelCurSubStates.at(0) = StateType::INITIAL_STATE;
     }
 
     switch (button)
     {
-        case panel::types::ButtonEvent::INCREMENT:
+        case types::ButtonEvent::INCREMENT:
             incrementState();
             break;
 
-        case panel::types::ButtonEvent::DECREMENT:
+        case types::ButtonEvent::DECREMENT:
             decrementState();
             break;
 
-        case panel::types::ButtonEvent::EXECUTE:
+        case types::ButtonEvent::EXECUTE:
             executeState();
             break;
 
@@ -192,10 +192,10 @@ void PanelStateManager::initPanelState()
     panelCurSubStates.push_back(StateType::INVALID_STATE);
 
     // create executorclass
-    funcExecutor = std::make_shared<panel::Executor>(transport);
+    funcExecutor = std::make_shared<Executor>(transport);
 }
 
-std::tuple<panel::types::FunctionNumber, panel::types::FunctionNumber>
+std::tuple<types::FunctionNumber, types::FunctionNumber>
     PanelStateManager::getPanelCurrentStateInfo() const
 {
     const PanelFunctionality& funcState = panelFunctions.at(panelCurState);
@@ -203,14 +203,13 @@ std::tuple<panel::types::FunctionNumber, panel::types::FunctionNumber>
 }
 
 // functionality 02
-void PanelStateManager::setIPLParameters(
-    const panel::types::ButtonEvent& button)
+void PanelStateManager::setIPLParameters(const types::ButtonEvent& button)
 {
     std::vector<std::string> subRange = functionality02.at(levelToOperate);
 
     switch (button)
     {
-        case panel::types::ButtonEvent::INCREMENT:
+        case types::ButtonEvent::INCREMENT:
             if (panelCurSubStates.at(levelToOperate) == subRange.size() - 1)
             {
                 panelCurSubStates.at(levelToOperate) = StateType::INITIAL_STATE;
@@ -221,7 +220,7 @@ void PanelStateManager::setIPLParameters(
             }
             break;
 
-        case panel::types::ButtonEvent::DECREMENT:
+        case types::ButtonEvent::DECREMENT:
             if (panelCurSubStates.at(levelToOperate) ==
                 StateType::INITIAL_STATE)
             {
@@ -233,7 +232,7 @@ void PanelStateManager::setIPLParameters(
             }
             break;
 
-        case panel::types::ButtonEvent::EXECUTE:
+        case types::ButtonEvent::EXECUTE:
             if (!isSubrangeActive)
             {
                 isSubrangeActive = true;
@@ -276,7 +275,7 @@ void PanelStateManager::incrementState()
 
     if (funcState.functionNumber == FUNCTION_02 && isSubrangeActive)
     {
-        setIPLParameters(panel::types::ButtonEvent::INCREMENT);
+        setIPLParameters(types::ButtonEvent::INCREMENT);
         return;
     }
 
@@ -341,7 +340,7 @@ void PanelStateManager::decrementState()
 
     if (funcState.functionNumber == FUNCTION_02 && isSubrangeActive)
     {
-        setIPLParameters(panel::types::ButtonEvent::DECREMENT);
+        setIPLParameters(types::ButtonEvent::DECREMENT);
         return;
     }
 
@@ -408,7 +407,7 @@ void PanelStateManager::executeState()
 
     if (funcState.functionNumber == FUNCTION_02)
     {
-        setIPLParameters(panel::types::ButtonEvent::EXECUTE);
+        setIPLParameters(types::ButtonEvent::EXECUTE);
         return;
     }
 
@@ -504,7 +503,7 @@ void PanelStateManager::createDisplayString() const
         }
     }
 
-    panel::utils::sendCurrDisplayToPanel(line1, std::string{}, transport);
+    utils::sendCurrDisplayToPanel(line1, std::string{}, transport);
 }
 
 void PanelStateManager::displayDebounce() const
@@ -519,7 +518,7 @@ void PanelStateManager::displayDebounce() const
         line1 += funcState.debouceSrc;
     }
 
-    panel::utils::sendCurrDisplayToPanel(line1, std::string{}, transport);
+    utils::sendCurrDisplayToPanel(line1, std::string{}, transport);
 }
 
 /**
@@ -552,7 +551,7 @@ void PanelStateManager::displayFunc02() const
             line2.replace(13, 1, 1, '<');
         }
     }
-    panel::utils::sendCurrDisplayToPanel(line1, line2, transport);
+    utils::sendCurrDisplayToPanel(line1, line2, transport);
 }
 } // namespace manager
 } // namespace state

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -40,7 +40,7 @@ void Transport::panelI2CSetup()
               << std::endl;
 }
 
-void Transport::panelI2CWrite(const panel::types::Binary& buffer) const
+void Transport::panelI2CWrite(const types::Binary& buffer) const
 {
     if (transportKey)
     {
@@ -71,7 +71,7 @@ void Transport::panelI2CWrite(const panel::types::Binary& buffer) const
 
 void Transport::doButtonConfig()
 {
-    panel::encoder::MessageEncoder encode;
+    encoder::MessageEncoder encode;
     panelI2CWrite(encode.buttonControl(0x00, 0x01));
     panelI2CWrite(encode.buttonControl(0x01, 0x01));
     panelI2CWrite(encode.buttonControl(0x02, 0x01));
@@ -80,7 +80,7 @@ void Transport::doButtonConfig()
 
 void Transport::setTransportKey(bool keyValue)
 {
-    if (!transportKey && keyValue && panelType == panel::types::PanelType::LCD)
+    if (!transportKey && keyValue && panelType == types::PanelType::LCD)
     {
         transportKey = keyValue;
         // TODO: Do soft reset when the transport key is active.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,7 @@ namespace panel
 {
 namespace utils
 {
-std::string binaryToHexString(const panel::types::Binary& val)
+std::string binaryToHexString(const types::Binary& val)
 {
     std::ostringstream oss;
     for (auto i : val)
@@ -18,13 +18,13 @@ std::string binaryToHexString(const panel::types::Binary& val)
 }
 
 void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
-                            std::shared_ptr<panel::Transport> transport)
+                            std::shared_ptr<Transport> transport)
 {
     // couts are for debugging purpose. can be removed once the testing is done.
     std::cout << "L1 : " << line1 << std::endl;
     std::cout << "L2 : " << line2 << std::endl;
 
-    panel::encoder::MessageEncoder encode;
+    encoder::MessageEncoder encode;
 
     auto displayPacket = encode.rawDisplay(line1, line2);
 


### PR DESCRIPTION
Some of the files are already grouped into the
panel namespace. So removing the recurring "panel"
prefix in the variables, functions and types wherever
required.

Change-Id: I304163a582f23f380482623acfec469d01aab92f
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>