### PR TITLE
Do panel soft reset

### DIFF
--- a/include/transport.hpp
+++ b/include/transport.hpp
@@ -93,5 +93,13 @@ class Transport
      * controller.
      */
     void panelI2CSetup();
+
+    /** @brief API to do soft reset.
+     * The Panel Code Soft Reset command is used to perform a soft reset of
+     * the Panel micro-controller. This will re-initialize the Panel micro-code
+     * to its start-up values. A delay of 100milliseconds is added after the
+     * soft reset operation.
+     */
+    void doSoftReset();
 };
 } // namespace panel

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -6,7 +6,9 @@
 #include <linux/i2c-dev.h>
 #include <sys/ioctl.h>
 
+#include <chrono>
 #include <cstring>
+#include <thread>
 
 namespace panel
 {
@@ -78,12 +80,20 @@ void Transport::doButtonConfig()
     std::cout << "\n Button configuration done." << std::endl;
 }
 
+void Transport::doSoftReset()
+{
+    using namespace std::chrono_literals;
+    panelI2CWrite(encoder::MessageEncoder().softReset());
+    std::this_thread::sleep_for(100ms);
+    std::cout << "\n Panel:Soft reset done." << std::endl;
+}
+
 void Transport::setTransportKey(bool keyValue)
 {
     if (!transportKey && keyValue && panelType == types::PanelType::LCD)
     {
         transportKey = keyValue;
-        // TODO: Do soft reset when the transport key is active.
+        doSoftReset();
         doButtonConfig();
     }
     else


### PR DESCRIPTION
The Panel Code Soft Reset command is used to
perform a soft reset of the Panel micro-controller
only when the transport key is set to active from
an inactive state, ie; only when the panel is
plugged in or at startup.
This will re-initialize the Panel micro-code to its
start-up values.

Change-Id: I4ea3c4244452424b3a45f6899c2f1339faa30e8f
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>