### PR TITLE
PEL event listener

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "executor.hpp"
+#include "panel_state_manager.hpp"
 #include "transport.hpp"
 
 #include <memory>
@@ -51,4 +53,56 @@ class PanelPresence
      */
     void readPresentProperty(sdbusplus::message::message& msg);
 };
+
+/** @class PELListener
+ * @brief Listen to PEL logged event.
+ *
+ * It will implement callback to listen for interface added against any PEL
+ * event logged in the bmc.
+ *
+ */
+class PELListener
+{
+  public:
+    PELListener(const PELListener&) = delete;
+    PELListener& operator=(const PELListener&) = delete;
+    PELListener(PELListener&&) = delete;
+    ~PELListener() = default;
+
+    /**
+     * @brief Constructor
+     * @param[in] con - Bus connection.
+     * @param[in] manager - Pointer to State manager.
+     * @param[in] execute - pointer to Executor.
+     */
+    PELListener(std::shared_ptr<sdbusplus::asio::connection> con,
+                std::shared_ptr<state::manager::PanelStateManager> manager,
+                std::shared_ptr<Executor> execute) :
+        conn(con),
+        stateManager(manager), executor(execute)
+    {
+    }
+
+    /**
+     * @brief Api to listen for PEL events.
+     */
+    void listenPelEvents();
+
+  private:
+    /* Callback to listen for PEL event log */
+    void PELEventCallBack(sdbusplus::message::message& msg);
+
+    /* Dbus connection */
+    std::shared_ptr<sdbusplus::asio::connection> conn;
+
+    /* state manager */
+    std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+    /* Executor */
+    std::shared_ptr<Executor> executor;
+
+    /* Check if respective functions are enabled */
+    bool functionStateEnabled = false;
+
+}; // class PEL Listener
 } // namespace panel

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -4,6 +4,7 @@
 #include "types.hpp"
 
 #include <memory>
+#include <sdbusplus/message/native_types.hpp>
 
 namespace panel
 {
@@ -43,6 +44,15 @@ class Executor
     void executeFunction(const types::FunctionNumber funcNumber,
                          const types::FunctionalityList& subFuncNumber);
 
+    /**
+     * @brief Api to store event path of last PEL.
+     * @param[in] lastPel - Object path of last PEL.
+     */
+    inline void lastPELId(const sdbusplus::message::object_path& lastPel)
+    {
+        pelEventPath = lastPel;
+    }
+
   private:
     /**
      * @brief An api to execute functionality 20
@@ -64,6 +74,9 @@ class Executor
 
     /*Transport class object*/
     std::shared_ptr<Transport> transport;
+
+    /* Event object path of last logged PEL */
+    sdbusplus::message::object_path pelEventPath{};
 
 }; // class Executor
 } // namespace panel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -20,6 +20,17 @@ using PanelDataTuple = std::tuple<std::string, uint8_t, std::string>;
 using PanelDataMap = std::unordered_map<std::string, PanelDataTuple>;
 using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 
+/* DbusInterfaceMap reference
+map{InterfaceName, map{propertyName, value}}
+*/
+using DbusInterfaceMap = std::map<
+    std::string,
+    std::map<
+        std::string,
+        std::variant<
+            bool, uint32_t, uint64_t, std::string, std::vector<std::string>,
+            std::vector<std::tuple<std::string, std::string, std::string>>>>>;
+
 /*baseBIOSTable reference
 map{attributeName,struct{attributeType,readonlyStatus,displayname,
               description,menuPath,current,default,

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -175,6 +175,9 @@ int main(int, char**)
 
         lcdPanel->setTransportKey(getPresentProperty(imValue));
 
+        // create executor class
+        auto executor = std::make_shared<panel::Executor>(lcdPanel);
+
         // create state manager object
         auto stateManager =
             std::make_shared<panel::state::manager::PanelStateManager>(
@@ -182,6 +185,9 @@ int main(int, char**)
 
         panel::ButtonHandler btnHandler(getInputDevicePath(imValue), io,
                                         lcdPanel, stateManager);
+
+        panel::PELListener pelEvent(conn, stateManager, executor);
+        pelEvent.listenPelEvents();
 
         io->run();
     }


### PR DESCRIPTION
This commit implements callback to listen for PEL logged event.
Once PEL event callback is received it enables functiona 11 to 13
based on the severity of the PEL.

Commit also implements changes to keep track of last logged PEL to
extract and use data related to the PEL as required.

Change-Id: If7b8707fdb4da51b1ccba30867363041477b0fde
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>