### PR TITLE
Panel identifies tacoma device

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -8,6 +8,8 @@ namespace constants
 static constexpr auto baseDevPath = "/dev/i2c-3";
 static constexpr auto rainLcdDevPath = "/dev/i2c-7";
 static constexpr auto everLcdDevPath = "/dev/i2c-28";
+static constexpr auto tacomaLcdDevPath = "/dev/i2c-0";
+
 static constexpr auto devAddr = 0x5a;
 
 static constexpr auto systemDbusObj =


### PR DESCRIPTION
When the panel code runs on tacoma device(test machine),
this commit picks up the right device path and
skips listening to panel presence dbus property.

Change-Id: I6808e8c06efad65a1130d2911f1c21713af8ce08
Signed-off-by: PriyangaRamasamy <priyanga24@in.ibm.com>