### PR TITLE
Enable scroll in display

### DIFF
--- a/include/types.hpp
+++ b/include/types.hpp
@@ -65,5 +65,12 @@ enum PanelType
     LCD
 };
 
+enum class ScrollType : Byte
+{
+    BOTH_LEFT = 0x01,
+    LINE1_LEFT = 0x11,
+    LINE2_LEFT = 0x21,
+};
+
 } // namespace types
 } // namespace panel

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -29,9 +29,22 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
     auto displayPacket = encode.rawDisplay(line1, line2);
 
     transport->panelI2CWrite(displayPacket);
-    // TODO: After sending display packet, pause for few seconds and send scroll
-    // command to scroll both the lines towards right, if the lines exceeds
-    // 16characters.
+
+    if ((line1.length() > 16) && (line2.length() > 16))
+    {
+        transport->panelI2CWrite(encode.scroll(
+            static_cast<types::Byte>(types::ScrollType::BOTH_LEFT)));
+    }
+    else if (line1.length() > 16)
+    {
+        transport->panelI2CWrite(encode.scroll(
+            static_cast<types::Byte>(types::ScrollType::LINE1_LEFT)));
+    }
+    else if (line2.length() > 16)
+    {
+        transport->panelI2CWrite(encode.scroll(
+            static_cast<types::Byte>(types::ScrollType::LINE2_LEFT)));
+    }
 }
 
 types::SystemParameterValues readSystemParameters()


### PR DESCRIPTION
If length of either of line1 or line2 (or) both line1
and line2 exceeds 16 characters, then send scroll
command to panel micro code to scroll left with a
scroll rate of 1 second and with the scroll
character count set to 1.

Change-Id: If13ebd45d5fc05145aab61dfef1cc3955e2e97c5
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>