### PR TITLE
Display progress code on LCD panel

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -105,4 +105,49 @@ class PELListener
     bool functionStateEnabled = false;
 
 }; // class PEL Listener
+
+/**
+ * @brief Progress code event handler.
+ * A class to register handler for progress code property channge.
+ */
+class BootProgressCode
+{
+  public:
+    BootProgressCode(const BootProgressCode&) = delete;
+    BootProgressCode& operator=(const BootProgressCode&) = delete;
+    BootProgressCode(BootProgressCode&&) = delete;
+    ~BootProgressCode() = default;
+
+    /**
+     * @brief Constructor.
+     * @param[in] transport - pointer to transport class.
+     * @param[in] con - Bus connection.
+     */
+    BootProgressCode(std::shared_ptr<Transport> transport,
+                     std::shared_ptr<sdbusplus::asio::connection> con) :
+        transport(transport),
+        conn(con)
+    {
+    }
+
+    /**
+     * @brief Api to register call back for progress code.
+     */
+    void listenProgressCode();
+
+  private:
+    /**
+     * @brief Callback handler.
+     * An Api to handle callback in case of progress code property change.
+     * @param[in] msg - Callback message.
+     */
+    void progressCodeCallBack(sdbusplus::message::message& msg);
+
+    /*Transport Class object */
+    std::shared_ptr<Transport> transport;
+
+    /* D-Bus connection. */
+    std::shared_ptr<sdbusplus::asio::connection> conn;
+
+}; // class BootProgressCode
 } // namespace panel

--- a/include/const.hpp
+++ b/include/const.hpp
@@ -40,5 +40,8 @@ static constexpr auto inventoryManagerIntf =
 static constexpr auto tmKwdDataLength = 8;
 static constexpr auto ccinDataLength = 4;
 
+// Progress code src equivalent to  ascii "00000000"
+static constexpr auto clearDisplayProgressCode = 0x3030303030303030;
+
 } // namespace constants
 } // namespace panel


### PR DESCRIPTION
This commit implements a class to handle callback for
property change event for boot progress code.

The file presence has also been renamed to bus_monitor
to accomodate both PanelPresence handler and boot progress
code handler.

Sample Outputs:
L1 : STANDBY
L2 :

L1 : RUNTIME
L2 :

L1 : C20011FF
L2 :

Change-Id: I7500ffeb7bdccce9ec2e1238a684e0c1a75efe3f
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>