### PR TITLE
Enable/Disable functions based on callouts

### DIFF
--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -58,6 +58,13 @@ class PanelStateManager
         const types::FunctionalityList& listOfFunctionalities);
 
     /**
+     * @brief Api to disable function(s).
+     * @param[in] listOfFunctionalities - A list of function(s) to be disabled.
+     * */
+    void disableFunctonality(
+        const types::FunctionalityList& listOfFunctionalities);
+
+    /**
      * @brief Api to process button event.
      * This api will be called in case of any button event, will process and
      * set the state of panel accordingly.

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -87,6 +87,28 @@ void PanelStateManager::enableFunctonality(
         }
         else
         {
+            std::cout << "Entry for function Number " << functionNumber
+                      << " not found" << std::endl;
+        }
+    }
+}
+
+void PanelStateManager::disableFunctonality(
+    const panel::types::FunctionalityList& listOfFunctionalities)
+{
+    for (const auto& functionNumber : listOfFunctionalities)
+    {
+        auto pos =
+            find_if(panelFunctions.begin(), panelFunctions.end(),
+                    [functionNumber](const PanelFunctionality& afunctionality) {
+                        return afunctionality.functionNumber == functionNumber;
+                    });
+        if (pos != panelFunctions.end())
+        {
+            pos->functionActiveState = false;
+        }
+        else
+        {
             std::cout << "Entry for functionality Number " << functionNumber
                       << " not found" << std::endl;
         }


### PR DESCRIPTION
This commit implements changes to enable/disable function
from 14 to 19 based on the number of callouts against last
pel logged.

Change-Id: Id56d4c2a763172078fe8751365c811c4a471eb8c
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>