### PR TITLE
Do not throw to shell

### DIFF
--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -189,7 +189,10 @@ int main(int, char**)
     catch (const std::exception& e)
     {
         std::cerr << e.what();
-        throw;
+        std::cerr << "Panel app exiting..." << std::endl;
+        // TODO: Need to rethrow here so that systemd can mark the service a
+        // failure. We will do that once Everest hardware is ready.
+        // https://github.com/ibm-openbmc/ibm-panel/issues/21
     }
     // Create the D-Bus invoker class
     // Create D-Bus signal handler


### PR DESCRIPTION
Everest hardware is not fixed yet to remove the LCD panel from
the I2C mux. Until such time that the hardware is fixed, do not
rethrow to the shell. This fixes CI issues due to flagging of failed
systemd services.

Change-Id: Id5b28904a09dac047202a9aadba40e5ed12d9cc1
Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>