### PR TITLE
Add missing function 20 execution

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -41,7 +41,9 @@ void Executor::executeFunction(const types::FunctionNumber funcNumber,
         case 19:
             execute14to19(funcNumber);
             break;
-
+        case 20:
+            execute20();
+            break;
         case 30:
             execute30(subFuncNumber);
             break;


### PR DESCRIPTION
Execution call for function 20 is missing after integrating functions 14
through 19. Add it back.

Change-Id: I2354fd6f21dafdeb68c33f83ff0bbbb748563213
Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>