### PR TITLE
Panel Exception class

### DIFF
--- a/include/exception.hpp
+++ b/include/exception.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+namespace panel
+{
+class BaseException : public std::exception
+{
+  public:
+    // deleted constructors
+    BaseException() = delete;
+    BaseException(const BaseException&) = delete;
+    BaseException(BaseException&&) = delete;
+
+    // delete overloading operators
+    BaseException& operator=(const BaseException&) = delete;
+    BaseException& operator=(const BaseException&&) = delete;
+
+    // default destructor
+    ~BaseException() = default;
+
+    /** @brief Constructor
+     * @param[in] msg - Error message.
+     */
+    explicit BaseException(const std::string& msg) : error(msg)
+    {
+    }
+
+    /** @brief what method
+     * This method overrides the what() method in base std::exception class.
+     */
+    inline const char* what() const noexcept override
+    {
+        return error.c_str();
+    }
+
+  private:
+    std::string error;
+};
+
+class FunctionFailure : public BaseException
+{
+  public:
+    // deleted constructors
+    FunctionFailure() = delete;
+    FunctionFailure(const FunctionFailure&) = delete;
+    FunctionFailure(FunctionFailure&&) = delete;
+
+    // delete overloading operators
+    FunctionFailure& operator=(const FunctionFailure&) = delete;
+    FunctionFailure& operator=(const FunctionFailure&&) = delete;
+
+    // default destructor
+    ~FunctionFailure() = default;
+
+    /** @brief Constructor
+     * @param[in] msg - Error message.
+     */
+    explicit FunctionFailure(const std::string& msg) : BaseException(msg)
+    {
+    }
+};
+} // namespace panel


### PR DESCRIPTION
The PanelException class defines custom exception
for op-panel. The PanelException class inherits C++
std::exception class and overrides its what() method
to return the error message.

Change-Id: I4a842d21cd3298955ca5f9e89d63aff89447c96e
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>