### PR TITLE
Missing call to initiate dbus interface

### DIFF
--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -184,6 +184,7 @@ int main(int, char**)
         panel::BootProgressCode progressCode(lcdPanel, conn);
         progressCode.listenProgressCode();
 
+        iface->initialize();
         io->run();
     }
     catch (const std::exception& e)


### PR DESCRIPTION
Panel interface is not initialised,
due to which the panel service "com.ibm.PanelApp"
is not able to discover its child objects.
This commit fixes the issue.

Change-Id: I68e87e8b5adc2c51d6420d2aea0aee6d2a168c88
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>