### PR TITLE
PEL: Do not store empty event IDs in queue

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -145,9 +145,6 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                         return;
                     }
                 }
-                // Store empty string if the evenId property is not found
-                // and log an error for reference.
-                executor->storePelEventId(std::string{});
                 std::cerr << "Event ID property not found" << std::endl;
             }
         }


### PR DESCRIPTION
This commit removes a piece of code that used to store empty
strings in the event ID queue. This would happen if the eventID
property was not found on the PEL object.

The event ID queue is used in various functions such as 11, 63, 64
and storing an empty string in the queue would mean that we show a
blank screen when these functions are executed. Since a blank screen
adds no additional value, it is best not to store empty strings
in the queue.

Change-Id: Ia403dfe5a35af5b6c141636b026787a10a3170ea
Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>