### PR TITLE
Logging: Comment out line display

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -20,9 +20,12 @@ std::string binaryToHexString(const types::Binary& val)
 void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
                             std::shared_ptr<Transport> transport)
 {
+    // TODO: via https://github.com/ibm-openbmc/ibm-panel/issues/37
+    // Make these couts and other traces in the code configurable. Keeping
+    // these commented until then as they flood the systemd journal.
     // couts are for debugging purpose. can be removed once the testing is done.
-    std::cout << "L1 : " << line1 << std::endl;
-    std::cout << "L2 : " << line2 << std::endl;
+    // std::cout << "L1 : " << line1 << std::endl;
+    // std::cout << "L2 : " << line2 << std::endl;
 
     encoder::MessageEncoder encode;
 


### PR DESCRIPTION
With numerous progress codes being displayed when we boot up to
PHYP and then the OS, the traces we have in the util display wrapper
easily overwhelm the systemd journal.

This commit comments those traces until such a time that we have
dynamically controlled logging.

Change-Id: I1060e405c999c6f161e678db1cd224c8f76d9a19
Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>