### PR TITLE
Implementation of function 73

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -155,6 +155,11 @@ class Executor
     void execute64(const types::FunctionNumber subFuncNumber);
 
     /**
+     * @brief An api to execute function 73.
+     */
+    void execute73();
+
+    /**
      * @brief Api to get PEL eventId.
      *
      * This is a helper function to get the eventId(SRC) data for the PEL

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -71,7 +71,10 @@ std::vector<FunctionalityAttributes> functionalityList = {
     {67, false, false, "NONE", StateType::INITIAL_STATE},
     {68, false, false, "NONE", StateType::INITIAL_STATE},
     {69, false, false, "NONE", StateType::INITIAL_STATE},
-    {70, false, false, "NONE", StateType::INITIAL_STATE}};
+    {70, false, false, "NONE", StateType::INITIAL_STATE},
+    // TODO: func 73 is enabled only after a certain condition, needs to be
+    // updated once the commit with enable/disable mask is in
+    {73, false, true, "A170800B", StateType::INITIAL_STATE}};
 
 void PanelStateManager::enableFunctonality(
     const types::FunctionalityList& listOfFunctionalities)


### PR DESCRIPTION
This commit implements factory reset functionality.
It triggers factory reset followed by BMC graceful restart.

Tested on simics:
path /var/lib/vpd was cleared after factory reset.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>

Change-Id: If6e418454386ec6a1e42f870b38e3763985c7357