### PR TITLE
remove transport key verbose log

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -64,11 +64,6 @@ void Transport::panelI2CWrite(const types::Binary& buffer) const
             std::cerr << "\n Buffer empty. Skipping I2C Write." << std::endl;
         }
     }
-    else
-    {
-        std::cout << "\n Transport Key is inactive. Cannot do raw i2c writes."
-                  << std::endl;
-    }
 }
 
 void Transport::doButtonConfig()


### PR DESCRIPTION
On our Rainier systems, this is filling up the journal log:

Oct 12 14:56:35 p10bmc ibm-panel[776]:  Transport Key is inactive. Cannot do raw i2c writes.
Oct 12 14:56:35 p10bmc ibm-panel[776]:  Transport Key is inactive. Cannot do raw i2c writes.
Oct 12 14:56:36 p10bmc ibm-panel[776]:  Transport Key is inactive. Cannot do raw i2c writes.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>