### PR TITLE
Lamp test D-bus method

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -21,15 +21,22 @@ class BusHandler
 
     /**
      * @brief Constructor.
-     * @param[in] iface - Pointer to dbus interface class.
+     * @param[in] transport - Transport class object.
+     * @param[in] iface - Pointer to Panel dbus interface.
      */
-    BusHandler(std::shared_ptr<sdbusplus::asio::dbus_interface>& iface) :
+    BusHandler(std::shared_ptr<Transport>& transport,
+               std::shared_ptr<sdbusplus::asio::dbus_interface>& iface) :
+        transport(transport),
         iface(iface)
     {
         iface->register_method("Display", [this](const std::string& line1,
                                                  const std::string& line2) {
             this->display(line1, line2);
         });
+
+        iface->register_method(
+            "TriggerPanelLampTest",
+            [this](const bool status) { this->triggerPanelLampTest(status); });
     }
 
   private:
@@ -45,6 +52,17 @@ class BusHandler
      */
     void display(const std::string& displayLine1,
                  const std::string& displayLine2);
+
+    /**
+     * @brief Dbus API to trigger panel lamp test.
+     * @param[in] state - If state is true, the panel lamp test command will be
+     * sent to the panel micro code. If false, then default function 01
+     * execution happens.
+     */
+    void triggerPanelLampTest(const bool state);
+
+    /* Pointer to transport class */
+    std::shared_ptr<Transport> transport;
 
     /* Pointer to interface */
     std::shared_ptr<sdbusplus::asio::dbus_interface> iface;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -143,5 +143,12 @@ void getNextBootSide(std::string& nextBootSide);
  */
 void doLampTest(std::shared_ptr<Transport>& transport);
 
+/**
+ * @brief Api to restore the current display state on panel.
+ * @param[in] transport - shared pointer object to transport class to send the
+ * display lines.
+ */
+void restoreDisplayOnPanel(std::shared_ptr<Transport>& transport);
+
 } // namespace utils
 } // namespace panel

--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "utils.cpp"
+
 namespace panel
 {
 void BusHandler::display(const std::string& displayLine1,
@@ -12,4 +14,17 @@ void BusHandler::display(const std::string& displayLine1,
     std::cout << displayLine1 << displayLine2 << std::endl;
     // Implement display function
 }
+
+void BusHandler::triggerPanelLampTest(const bool state)
+{
+    if (state)
+    {
+        utils::doLampTest(transport);
+    }
+    else
+    {
+        utils::restoreDisplayOnPanel(transport);
+    }
+}
+
 } // namespace panel

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -188,7 +188,6 @@ int main(int, char**)
                       << std::endl;
         }
 
-        panel::BusHandler busHandle(iface);
 
         panel::PELListener pelEvent(conn, stateManager, executor);
         pelEvent.listenPelEvents();
@@ -196,6 +195,8 @@ int main(int, char**)
         // register property change call back for progress code.
         panel::BootProgressCode progressCode(lcdPanel, conn, executor);
         progressCode.listenProgressCode();
+
+        panel::BusHandler busHandle(lcdPanel, iface);
 
         iface->initialize();
         io->run();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,6 +6,9 @@ namespace panel
 {
 namespace utils
 {
+// Global variables to restore state of display lines.
+std::string restoreLine1, restoreLine2;
+
 std::string binaryToHexString(const types::Binary& val)
 {
     std::ostringstream oss;
@@ -26,6 +29,10 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
     // couts are for debugging purpose. can be removed once the testing is done.
     // std::cout << "L1 : " << line1 << std::endl;
     // std::cout << "L2 : " << line2 << std::endl;
+
+    // Restore the values of display lines
+    restoreLine1 = line1;
+    restoreLine2 = line2;
 
     encoder::MessageEncoder encode;
 
@@ -292,6 +299,11 @@ void doLampTest(std::shared_ptr<Transport>& transport)
 {
     transport->panelI2CWrite(encoder::MessageEncoder().lampTest());
     std::cout << "\nPanel lamp test initiated." << std::endl;
+}
+
+void restoreDisplayOnPanel(std::shared_ptr<Transport>& transport)
+{
+    sendCurrDisplayToPanel(restoreLine1, restoreLine2, transport);
 }
 
 } // namespace utils


### PR DESCRIPTION
Panel hosts a new dbus method called "TriggerPanelLampTest" which
takes a boolean input indicating the request status to trigger
lamp test.

When boolean takes true, the lamp test request is sent to the
panel and when false, panel restores the current display state.

Test:
Tested on rainier.

1. For test purpose : Executed function 30 before triggering panel lamp test.

root@rain71bmc:/tmp# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel  TriggerPanelLampTest b false

Journal Log:
Oct 06 15:26:15 rain127bmc ibm-panel[5061]: L1 : SP: ETH0:      T0
Oct 06 15:26:15 rain127bmc ibm-panel[5061]: L2 : 9.3.29.238

2.
root@rain71bmc:/tmp# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel  TriggerPanelLampTest b true

Journal Log:
Sep 15 16:51:01 rain71bmc ibm-panel[1672]:  Panel lamp test initiated.

Change-Id: Iaa1120bb5fd8314ac386f9bfe07f81f87d8e6152
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>