### PR TITLE
Generic GetPDR method

### DIFF
--- a/include/pldm_fw.hpp
+++ b/include/pldm_fw.hpp
@@ -90,11 +90,20 @@ class PldmFramework
     types::Byte getInstanceID();
 
     /**
-     * @brief Find panel state effecter PDR
-     * This api returns the state effecter pdr for panel.
+     * @brief Find and retrieve the PDR.
+     * This api returns the pdr for the given terminusId, entityId and
+     * stateSetId.
+     *
+     * @param[in] terminusId - PLDM terminus id.
+     * @param[in] entityId - Id representing an entity associated to the given
+     * PLDM state set.
+     * @param[in] stateSetId - Id representing PLDM state set.
+     * @param[in] pdrMethod - PDR method name
+     * (FindStateEffecterPDR/FindStateSensorPDR).
      *
      * @return PDR data.
      */
-    PdrList getPanelStateEffecterPDR();
+    PdrList getPDR(const uint8_t& terminusId, const uint16_t& entityId,
+                   const uint16_t& stateSetId, const std::string& pdrMethod);
 };
 } // namespace panel


### PR DESCRIPTION
This commit replaces getPanelStateEffecterPDR method
with a common getPDR method which can return both the
pldm state effecter pdrs and sensor pdrs for any type
of pldm entity.

Change-Id: I10f30e679e0ce81604c27145a203cdbd94522601
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>