### PR TITLE
Executor method to trigger PHYP functions

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -208,6 +208,16 @@ class Executor
      */
     void execute43();
 
+    /**
+     * @brief API to send function number to PHYP.
+     * Some of the functions(like 21,22,34,41,65-70) needs to be executed by
+     * PHYP. This method sends the function number to phyp via the PldmFramework
+     * api and displays 00 on a successful send and FF on a failure.
+     *
+     * @param[in] funcNumber - Function number.
+     */
+    void sendFuncNumToPhyp(const types::FunctionNumber& funcNumber);
+
     /*Transport class object*/
     std::shared_ptr<Transport> transport;
 

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ if get_option('tests').enabled()
           sdbusplus,
           gmock,
           gtest,
+          dependency('libpldm')
       ],
       include_directories: [
           'include',

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -2,6 +2,7 @@
 
 #include "const.hpp"
 #include "exception.hpp"
+#include "pldm_fw.hpp"
 #include "utils.hpp"
 
 #include <boost/algorithm/string.hpp>
@@ -89,6 +90,20 @@ void Executor::executeFunction(const types::FunctionNumber funcNumber,
             case 20:
                 execute20();
                 break;
+
+            case 21:
+            case 22:
+            case 34:
+            case 41:
+            case 65:
+            case 66:
+            case 67:
+            case 68:
+            case 69:
+            case 70:
+                sendFuncNumToPhyp(funcNumber);
+                break;
+
             case 30:
                 execute30(subFuncNumber);
                 break;
@@ -935,6 +950,14 @@ void Executor::execute73()
 
     // Factory Reset doesn't actually happen until a reboot
     doBMCGracefulRestart();
+}
+
+void Executor::sendFuncNumToPhyp(const types::FunctionNumber& funcNumber)
+{
+    PldmFramework obj;
+    obj.sendPanelFunctionToPhyp(funcNumber);
+    displayExecutionStatus(funcNumber, std::vector<types::FunctionNumber>(),
+                           true);
 }
 
 } // namespace panel


### PR DESCRIPTION
This commit implements a method in executor class
to trigger those functions executed by PHYP, whenever
there occurs a button press for such functions.

Change-Id: Icacac6ea763584f523b89e6b290880c1d503da74
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>