### PR TITLE
PEL terminating bit handle

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -74,12 +74,14 @@ class PELListener
      * @param[in] con - Bus connection.
      * @param[in] manager - Pointer to State manager.
      * @param[in] execute - pointer to Executor.
+     * @param[in] transport - pointer to transport class.
      */
     PELListener(std::shared_ptr<sdbusplus::asio::connection> con,
                 std::shared_ptr<state::manager::PanelStateManager> manager,
-                std::shared_ptr<Executor> execute) :
+                std::shared_ptr<Executor> execute,
+                std::shared_ptr<Transport>& transport) :
         conn(con),
-        stateManager(manager), executor(execute)
+        stateManager(manager), executor(execute), transport(transport)
     {
     }
 
@@ -100,6 +102,9 @@ class PELListener
 
     /* Executor */
     std::shared_ptr<Executor> executor;
+
+    /* pointer to Transport class*/
+    std::shared_ptr<Transport> transport;
 
     /* Check if respective functions are enabled */
     bool functionStateEnabled = false;

--- a/include/const.hpp
+++ b/include/const.hpp
@@ -43,6 +43,8 @@ static constexpr auto locCodeIntf =
 
 static constexpr auto tmKwdDataLength = 8;
 static constexpr auto ccinDataLength = 4;
+static constexpr auto fiveHexWordsWithSpaces = 44;
+static constexpr auto terminatingBit = 2;
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -188,7 +188,7 @@ int main(int, char**)
                       << std::endl;
         }
 
-        panel::PELListener pelEvent(conn, stateManager, executor);
+        panel::PELListener pelEvent(conn, stateManager, executor, lcdPanel);
         pelEvent.listenPelEvents();
 
         // register property change call back for progress code.


### PR DESCRIPTION
This commit implements change to handle terminating bit in
the SRC of PELs logged by BMC.
In case the bit is set the SRC is directly sent to the LCD
display.

Change-Id: I740e7d254e1a6f85dbb88c28f831706956d48d83
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>