### PR TITLE
Implementation of function 25 and 26

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -90,6 +90,17 @@ class Executor
         return iplSrcs.size();
     }
 
+    /**
+     * @brief An api to get state of service switch 1.
+     * It is required to enable CE mode by state manager.
+     *
+     * @return state of service switch 1.
+     */
+    inline bool getServiceSwitch1State() const
+    {
+        return serviceSwitch1State;
+    }
+
   private:
     /**
      * @brief An api to execute functionality 20
@@ -141,6 +152,21 @@ class Executor
      * @param[in] funcNumber - function to execute.
      */
     void execute14to19(const types::FunctionNumber funcNumber);
+
+    /**
+     * @brief An api to execute function 25.
+     * Function 25 along with function 26 is usd to enable CE mode functions in
+     * panel.
+     */
+    void execute25();
+
+    /**
+     * @brief An api to execute function 26.
+     * Function 26 when executed after function 25 enables CE mode in panel. If
+     * function 25 has not been executed before function 26, then execution of
+     * this function will fail and FF will be displayed.
+     */
+    void execute26();
 
     /**
      * @brief An api to execute function 63.
@@ -230,5 +256,7 @@ class Executor
     /* Queue of last 25 PEL SRCs */
     std::deque<std::string> pelEventIdQueue;
 
+    /*State of function 25 excution. Needed for function 26*/
+    bool serviceSwitch1State = false;
 }; // class Executor
 } // namespace panel

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -124,6 +124,11 @@ class PanelStateManager
      */
     void setSystemOperatingMode(const std::string& operatingMode);
 
+    /**
+     * @brief An api to enable/disable CE mode.
+     */
+    void setCEState();
+
   private:
     /**
      * @brief An Api to set the initial state of PanelState class.


### PR DESCRIPTION
This commit implements function 25 and 26 which are referred as
"Service Switch 1" and "Service Switch 2" respectively.

The Service Switch functions are only available in manual
operating mode when activated. Function 25 (Service Switch 1) and
Function 26 (Service Switch 2) can be used to enable or disable
the CE functions scroll range.

When the CE mode is disabled, a Service Switch 1 followed by a
Service Switch 2 enables that.

When the CE mode is enabled, execution of either function 25 or
function 26 disable the mode.

Change-Id: I5e5e0534bdade385f7395ad48fee34c7b5b8af78
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>