### PR TITLE
Fix for Lamp test issue

### DIFF
--- a/include/i2c_message_encoder.hpp
+++ b/include/i2c_message_encoder.hpp
@@ -89,8 +89,8 @@ class MessageEncoder
      * The Lamp Test command is used to perform a lamp test on all illumination
      * elements (LED, LCD) on the converged Panel.
      * The encoded data packet contains the command code of lamp test command
-     * (0xFF54); the lamp test duration which is defaulted to 240seconds; along
-     * with the calculated checksum.
+     * (0xFF54); the lamp test duration which is defaulted to 240seconds; lamp
+     * test period and lamp test on period along with the calculated checksum.
      * @return Encoded data packet of lamp test command.
      */
     Binary lampTest();

--- a/src/i2c_message_encoder.cpp
+++ b/src/i2c_message_encoder.cpp
@@ -89,10 +89,12 @@ Binary MessageEncoder::scroll(Byte scrollControl)
 Binary MessageEncoder::lampTest()
 {
     Binary encodedData;
-    encodedData.reserve(4);
+    encodedData.reserve(6);
     encodedData.emplace_back(0xFF);
     encodedData.emplace_back(0x54);
     encodedData.emplace_back(240); // emplace lamp test duration
+    encodedData.emplace_back(50);  // emplace lamp test period
+    encodedData.emplace_back(50);  // emplace lamp test on period
     calculateCheckSum(encodedData);
     return encodedData;
 }

--- a/test/i2c_message_encoder_test.cpp
+++ b/test/i2c_message_encoder_test.cpp
@@ -110,7 +110,7 @@ TEST(MessageEncoder, scroll)
 TEST(MessageEncoder, lampTest)
 {
     MessageEncoder msgEncode;
-    Binary validData = {0xFF, 0x54, 240, 187};
+    Binary validData = {0xFF, 0x54, 240, 50, 50, 87};
     EXPECT_EQ(validData, msgEncode.lampTest());
 }
 


### PR DESCRIPTION
Issue:
Missing 2 bytes of data in the lamp test command.
(lamp test period and lamp test on period).

This commit has the updated lamp test command.

Change-Id: Ie8fbf57f248178cb377402e9e4973f4798e50313
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>