### PR TITLE
Panel function 74 implementation

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -45,6 +45,10 @@ class BusHandler
                                [this](const types::FunctionalityList& list) {
                                    this->toggleFunctionState(list);
                                });
+
+        iface->register_property(
+            "ACFWindowActive", false,
+            sdbusplus::asio::PropertyPermission::readWrite);
     }
 
   private:

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -5,6 +5,7 @@
 
 #include <deque>
 #include <memory>
+#include <sdbusplus/asio/object_server.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
 namespace panel
@@ -26,8 +27,14 @@ class Executor
     /**
      * @brief Constructor
      * @param[in] transport - Pointer to transport class.
+     * @param[in] iface - Pointer to Panel dbus interface.
+     * @param[in] io - reference to io context class.
      */
-    Executor(std::shared_ptr<Transport> transport) : transport(transport)
+    Executor(std::shared_ptr<Transport> transport,
+             std::shared_ptr<sdbusplus::asio::dbus_interface>& iface,
+             std::shared_ptr<boost::asio::io_context>& io) :
+        transport(transport),
+        iface(iface), io_context(io)
     {
     }
 
@@ -186,6 +193,11 @@ class Executor
     void execute73();
 
     /**
+     * @brief An api to execute function 74.
+     */
+    void execute74();
+
+    /**
      * @brief Api to get PEL eventId.
      *
      * This is a helper function to get the eventId(SRC) data for the PEL
@@ -258,5 +270,12 @@ class Executor
 
     /*State of function 25 excution. Needed for function 26*/
     bool serviceSwitch1State = false;
+
+    /* Pointer to interface */
+    std::shared_ptr<sdbusplus::asio::dbus_interface> iface;
+
+    /* Event for timer required in function 74 */
+    std::shared_ptr<boost::asio::io_context> io_context;
+
 }; // class Executor
 } // namespace panel

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -164,7 +164,7 @@ int main(int, char**)
         }
 
         // create executor class
-        auto executor = std::make_shared<panel::Executor>(lcdPanel);
+        auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io);
 
         // create state manager object
         auto stateManager =

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -155,6 +155,8 @@ std::vector<FunctionalityAttributes> functionalityList = {
       SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_BY_PHYP |
       SystemStateMask::ENABLE_CE_MODE)},
     {73, false, true, "A170800B", StateType::INITIAL_STATE,
+     (SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_CE_MODE)},
+    {74, false, false, "NONE", StateType::INITIAL_STATE,
      (SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_CE_MODE)}};
 
 void PanelStateManager::enableFunctonality(

--- a/test/panel_state_manager_test.cpp
+++ b/test/panel_state_manager_test.cpp
@@ -2,6 +2,8 @@
 #include "transport.hpp"
 #include "types.hpp"
 
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
 #include <tuple>
 
 #include <gtest/gtest.h>
@@ -17,8 +19,13 @@ using namespace std;
 
 // NOTE: Using "up", "down" and "enter" till we implement actual button events.
 // Will be modified later.
+auto io_con = std::make_shared<boost::asio::io_context>();
+auto dummy_conn = std::make_shared<sdbusplus::asio::connection>(*io_con);
+auto iface = std::make_shared<sdbusplus::asio::dbus_interface>(
+    dummy_conn, std::string{}, std::string{});
+
 auto lcdPanel = std::make_shared<panel::Transport>();
-auto executor = std::make_shared<panel::Executor>(lcdPanel);
+auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io_con);
 
 TEST(PanelStateManager, default_state)
 {


### PR DESCRIPTION
The function on execution triggers a timer for a given
duration and sets Dbus property to mark window to upload
ACF certificate as active.
This property should be looked upon by Bmcweb to detect
if the window has been enabled.

Upon timer expiration the window is set as disabled.

Change-Id: I51a890b48c38fc52d94ff336a469f89c95f26160
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>