### PR TITLE
Fetch existing PELs

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -94,6 +94,24 @@ class PELListener
     /* Callback to listen for PEL event log */
     void PELEventCallBack(sdbusplus::message::message& msg);
 
+    /**
+     * @brief An Api to set panel function state based on PEL data.
+     * @param[in]propValueMap - Map of property and value for the PEL.
+     */
+    void
+        setPelRelatedFunctionState(const types::PropertyValueMap& propValueMap);
+
+    /**
+     * @brief An Api to get list of PELs logged in the system.
+     */
+    void getListOfExistingPels();
+
+    /**
+     * @brief An Api to filter PELs of desired severity and eventId.
+     * @param[in] listOfPels - List of existing PELs in the system.
+     */
+    void filterPel(const types::GetManagedObjects& listOfPels);
+
     /* Dbus connection */
     std::shared_ptr<sdbusplus::asio::connection> conn;
 

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -24,16 +24,18 @@ using PanelDataMap = std::unordered_map<std::string, PanelDataTuple>;
 using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 using PldmPacket = std::vector<uint8_t>;
 
+// map{property::value}
+using PropertyValueMap = std::map<
+    std::string,
+    std::variant<
+        std::string, bool, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+        int64_t, uint64_t, double, std::vector<std::string>,
+        std::vector<std::tuple<std::string, std::string, std::string>>>>;
+
 /* DbusInterfaceMap reference
 map{InterfaceName, map{propertyName, value}}
 */
-using DbusInterfaceMap = std::map<
-    std::string,
-    std::map<
-        std::string,
-        std::variant<
-            bool, uint32_t, uint64_t, std::string, std::vector<std::string>,
-            std::vector<std::tuple<std::string, std::string, std::string>>>>>;
+using DbusInterfaceMap = std::map<std::string, PropertyValueMap>;
 
 /*baseBIOSTable reference
 map{attributeName,struct{attributeType,readonlyStatus,displayname,
@@ -56,18 +58,19 @@ using BiosBaseTable = std::vector<BiosBaseTableItem>;
 using SystemParameterValues =
     std::tuple<std::string, std::string, std::string, std::string, std::string>;
 
+// map{Interface : map{property:value}}
+using InterfacePropertyPair = std::pair<std::string, PropertyValueMap>;
+
+// map{Object path, InterfacePropertyPair}
+using singleObjectEntry = std::pair<sdbusplus::message::object_path,
+                                    std::vector<InterfacePropertyPair>>;
+
 /** Get managed objects for Network manager:
- * array{pair(network-object-paths : array{pair(all-interfaces-of-that-obj-path
- * : map(property-of-that-interface-if-any : property-value))})}
+ * array{pair(network-object-paths :
+ * array{pair(all-interfaces-of-that-obj-path :
+ * map(property-of-that-interface-if-any : property-value))})}
  */
-using GetManagedObjects = std::vector<std::pair<
-    sdbusplus::message::object_path,
-    std::vector<std::pair<
-        std::string,
-        std::map<std::string,
-                 std::variant<std::string, bool, uint8_t, int16_t, uint16_t,
-                              int32_t, uint32_t, int64_t, uint64_t, double,
-                              std::vector<std::string>>>>>>>;
+using GetManagedObjects = std::vector<singleObjectEntry>;
 
 using AttributeValueType = std::variant<int64_t, std::string>;
 using PendingAttributesItemType =


### PR DESCRIPTION
This commit implement changes to fetch list of any existing
PEL that is present in the system when panel process comes up.

If found it sorts the list to filter last 25 PELs logged in
the system of desired severity, enables panel function w.r.t.
that and stores event ID of those PELs.

Change-Id: If932ffad3c4586f9f7bac9be52e5b4c6fc9010c5
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>