### PR TITLE
Clang issue:Remove brace initialiser in string

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -362,7 +362,7 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message::message& msg)
 {
     using PostCode = std::tuple<uint64_t, std::vector<types::Byte>>;
 
-    std::string interface{};
+    std::string interface;
     std::map<std::string, std::variant<PostCode>> propertyMap;
 
     msg.read(interface, propertyMap);


### PR DESCRIPTION
Clang format running in openbmc jenkins expects string var{};
to be initialised as.
string var{
};
and throws error.
This commit removes the brace initialisation of the string
variable.

Change-Id: I518896b31e4fe356e1fd4d021c6db03b483efd90
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>