### PR TITLE
Better trace statement for transport key

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -95,7 +95,9 @@ void Transport::setTransportKey(bool keyValue)
     {
         transportKey = keyValue;
     }
-    std::cout << "\nTransport key is set to " << transportKey << std::endl;
+    std::cout << "\nTransport key is set to " << transportKey
+              << " for the panel at " << devPath << ", " << devAddress
+              << std::endl;
 }
 
 } // namespace panel


### PR DESCRIPTION
Modified the trace statement to say for which device path
and device address does the transport key is set.

Change-Id: I9bddf77940050f05c40ae8997495e50c762d0e14
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>