### PR TITLE
Code fix to check CE mode condition

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -49,7 +49,7 @@ void Executor::executeFunction(const types::FunctionNumber funcNumber,
     // function 25 executed state.
     // Function 26 is included here as func26 execution will need the state of
     // func25.
-    if (serviceSwitch1State && (funcNumber != 25 || funcNumber != 26))
+    if (serviceSwitch1State && funcNumber != 25 && funcNumber != 26)
     {
         serviceSwitch1State = false;
     }


### PR DESCRIPTION
Service switch 1 should be disabled if service-switch1 state is
already set and the currrently executed function is other than
function 25 and 26.
The condition check has been fixed in this commit.

Change-Id: I7e9269967ee92b79abcbc8b1933ef1211d8c8b82
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>