### PR TITLE
Update PELs processing implementation

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -96,10 +96,10 @@ class PELListener
 
     /**
      * @brief An Api to set panel function state based on PEL data.
-     * @param[in]propValueMap - Map of property and value for the PEL.
+     * @param[in]pelObjPath - Object path of the PEL logged.
      */
-    void
-        setPelRelatedFunctionState(const types::PropertyValueMap& propValueMap);
+    void setPelRelatedFunctionState(
+        const sdbusplus::message::object_path& pelObjPath);
 
     /**
      * @brief An Api to get list of PELs logged in the system.


### PR DESCRIPTION
There is a time gap in between the
xyz.openbmc_project.Logging.Entry interface being created
and EventID property being updated,
Hence, processing PELs w.r.t. interfaceAdded event for
xyz.openbmc_project.Logging.Entry leads to the issue where
eventId property is found to be empty.

To fix this issue PELs are now processed w.r.t to interfaceAdded
signal for org.open_power.Logging.PEL.Entry, which insures that
all the required property to process PELs by panel has been
populated.

Change-Id: I868d340518fd76ec06b03191cb33b954641d38d8
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>