### PR TITLE
Code fix to handle I2C write failure

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -48,15 +48,22 @@ void Transport::panelI2CWrite(const types::Binary& buffer) const
     {
         if (buffer.size()) // check if the given buffer has data in it.
         {
-            auto returnedSize =
-                write(panelFileDescriptor, buffer.data(), buffer.size());
-            if (returnedSize !=
-                static_cast<int>(buffer.size())) // write failure
+            static constexpr auto maxRetry = 5; // Just a random value
+            for (auto retryLoop = 0; retryLoop < maxRetry; ++retryLoop)
             {
-                std::cerr << "\n I2C Write failure. Errno : " << errno
-                          << ". Errno description : " << strerror(errno)
-                          << ". Bytes written = " << returnedSize
-                          << ". Actual Bytes = " << buffer.size() << std::endl;
+                auto returnedSize =
+                    write(panelFileDescriptor, buffer.data(), buffer.size());
+                if (returnedSize !=
+                    static_cast<int>(buffer.size())) // write failure
+                {
+                    std::cerr << "\n I2C Write failure. Errno : " << errno
+                              << ". Errno description : " << strerror(errno)
+                              << ". Bytes written = " << returnedSize
+                              << ". Actual Bytes = " << buffer.size()
+                              << ". Retry = " << retryLoop << std::endl;
+                    continue;
+                }
+                break;
             }
         }
         else


### PR DESCRIPTION
There has been cases where frequent button events has
thrown I2C protocol error while writing on panel display.
To overcome those situations and keep state manager in
sync with the dislay code has been fixed to trigger retries
in case of I2C write failure.

Change-Id: I38724dc005d7eebe0865eda2d6eafeca1b7612c8
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>