### PR TITLE
Get OS IPL mode state from PHYP

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.hpp"
+
 namespace panel
 {
 namespace constants
@@ -48,6 +50,16 @@ static constexpr auto terminatingBit = 2;
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;
+static constexpr auto phypTerminusID = (types::Byte)208;
+
+// Reference: PLDM Entity and State Set IDs in DSP0249_1.1.0 specification.
+// The Virtual machine manager is a logical entity, so bit 15 need to be set.
+// VMM Entity ID is referred from
+// https://github.ibm.com/openbmc/pldm/blob/1020/libpldm/entity.h#L34
+static constexpr uint16_t vmmEntityId = 33 | 0x8000; // logical value - 32801
+// TODO: Add the reference to the state set id present in pldm state_set.h
+// header file. Currently this info is not in pldm_state_set.h.
+static constexpr uint16_t osIplModeStateSetId = (uint16_t)32777;
 
 } // namespace constants
 } // namespace panel

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "pldm_dbus_signals.hpp"
 #include "transport.hpp"
 #include "types.hpp"
 
@@ -29,12 +30,14 @@ class Executor
      * @param[in] transport - Pointer to transport class.
      * @param[in] iface - Pointer to Panel dbus interface.
      * @param[in] io - reference to io context class.
+     * @param[in] sensorEvents - Sensor event object to query osIPLMode.
      */
     Executor(std::shared_ptr<Transport> transport,
              std::shared_ptr<sdbusplus::asio::dbus_interface>& iface,
-             std::shared_ptr<boost::asio::io_context>& io) :
+             std::shared_ptr<boost::asio::io_context>& io,
+             std::shared_ptr<PLDMSensorEvents>& sensorEvents) :
         transport(transport),
-        iface(iface), io_context(io)
+        iface(iface), io_context(io), sensorEvents(sensorEvents)
     {
     }
 
@@ -276,6 +279,11 @@ class Executor
 
     /* Event for timer required in function 74 */
     std::shared_ptr<boost::asio::io_context> io_context;
+
+    /* PLDM Sensor Events object to handle PLDM emitted state sensor dbus
+     * signals.
+     */
+    std::shared_ptr<PLDMSensorEvents> sensorEvents;
 
 }; // class Executor
 } // namespace panel

--- a/include/pldm_dbus_signals.hpp
+++ b/include/pldm_dbus_signals.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "const.hpp"
+#include "utils.hpp"
+
+#include <sdbusplus/asio/object_server.hpp>
+
+namespace panel
+{
+/**
+ * @brief Class to handle PLDM sensor events.
+ * When the PLDM daemon receives a sensorEvent of type stateSensorState, it
+ * emits the StateSensorEvent signal. This signal would be used by PLDM
+ * requester apps on the BMC, which will rely on this signal to determine state
+ * changes on a connected PLDM entity.
+ */
+class PLDMSensorEvents
+{
+  public:
+    PLDMSensorEvents(const PLDMSensorEvents&) = delete;
+    PLDMSensorEvents& operator=(const PLDMSensorEvents&) = delete;
+    PLDMSensorEvents(PLDMSensorEvents&&) = delete;
+    PLDMSensorEvents& operator=(const PLDMSensorEvents&&) = delete;
+    ~PLDMSensorEvents() = default;
+
+    /** @brief Default constructor for test case only. */
+    PLDMSensorEvents()
+    {
+    }
+
+    /** @brief Parameterised constructor.
+     * @param[in] conn - Panel sdbusplus connection object.
+     */
+    PLDMSensorEvents(std::shared_ptr<sdbusplus::asio::connection>& conn) :
+        bus(conn)
+    {
+        types::PdrList pdr = utils::getPDR(
+            panel::constants::phypTerminusID, panel::constants::vmmEntityId,
+            panel::constants::osIplModeStateSetId, "FindStateSensorPDR");
+        utils::getSensorDataFromPdr(pdr, osIPLModeSensorId);
+        listenStateSensorEvent();
+    }
+
+    /** @brief Is OS IPL mode setting enabled by PHYP or not.
+     * This api returns if the OS IPL mode setting is enabled by PHYP or not.
+     * @return true if enabled; false otherwise.
+     */
+    inline bool isOSIPLModeSettingEnabled()
+    {
+        return (osIPLModeState == 1);
+    }
+
+    /** @brief API to register PLDM state sensor event. */
+    void listenStateSensorEvent();
+
+  private:
+    /** @brief Call back to the registered PLDM state sensor event.
+     * @param[in] msg - Message received from the PLDM state sensor event.
+     */
+    void stateSensorCallback(sdbusplus::message::message& msg);
+
+    /** Panel sdbusplus connection object. */
+    std::shared_ptr<sdbusplus::asio::connection> bus;
+
+    /** Match signal object for PLDM state sensor event. */
+    std::unique_ptr<sdbusplus::bus::match::match> pldmEventSignal;
+
+    /** OS IPL mode sensor ID defaults to 0. */
+    uint16_t osIPLModeSensorId = 0;
+
+    /** OS IPL Mode state by default disabled by PHYP with a value 2. */
+    uint8_t osIPLModeState = 2;
+
+}; // PLDMSensorEvents
+
+} // namespace panel

--- a/include/pldm_fw.hpp
+++ b/include/pldm_fw.hpp
@@ -44,7 +44,6 @@ class PldmFramework
     static constexpr auto mctpEid = (types::Byte)9;
 
     // Constants required for PLDM packet.
-    static constexpr auto phypTerminusID = (types::Byte)208;
     static constexpr auto frontPanelBoardEntityId = (uint16_t)32837;
     static constexpr auto stateIdToEnablePanelFunc = (uint16_t)32778;
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -171,7 +171,6 @@ types::PdrList getPDR(const uint8_t& terminusId, const uint16_t& entityId,
  * @brief Get sensor data like sensor id from the PDR.
  * @param[in] stateSensorPdr - sensor PDR.
  * @param[out] sensorId - sensor id fetched from sensor PDR.
- * PDR.
  */
 void getSensorDataFromPdr(const types::PdrList& stateSensorPdr,
                           uint16_t& sensorId);

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ panel_app_a = static_library(
     'src/bus_monitor.cpp',
     'src/executor.cpp',
     'src/pldm_fw.cpp',
+    'src/pldm_dbus_signals.cpp',
     include_directories: 'include'
 )
 

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -476,9 +476,7 @@ void Executor::execute30(const types::FunctionalityList& subFuncNumber)
 
 bool Executor::isOSIPLTypeEnabled() const
 {
-    // TODO: Check with PLDM how they will communicate if IPL type is
-    // enabled or disabled. Till then return dummy value as false.
-    return false;
+    return sensorEvents->isOSIPLModeSettingEnabled();
 }
 
 void Executor::execute01()

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -2,6 +2,7 @@
 #include "bus_monitor.hpp"
 #include "button_handler.hpp"
 #include "const.hpp"
+#include "pldm_dbus_signals.hpp"
 #include "utils.hpp"
 
 #include <exception>
@@ -163,8 +164,11 @@ int main(int, char**)
             lcdPanel->setTransportKey(true);
         }
 
+        auto sensorEvents = std::make_shared<panel::PLDMSensorEvents>(conn);
+
         // create executor class
-        auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io);
+        auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io,
+                                                          sensorEvents);
 
         // create state manager object
         auto stateManager =

--- a/src/pldm_dbus_signals.cpp
+++ b/src/pldm_dbus_signals.cpp
@@ -1,0 +1,36 @@
+#include "pldm_dbus_signals.hpp"
+
+namespace panel
+{
+void PLDMSensorEvents::listenStateSensorEvent()
+{
+    // Matches on the pldm StateSensorEvent signal
+    pldmEventSignal = std::make_unique<sdbusplus::bus::match::match>(
+        *bus,
+        sdbusplus::bus::match::rules::type::signal() +
+            sdbusplus::bus::match::rules::member("StateSensorEvent") +
+            sdbusplus::bus::match::rules::path("/xyz/openbmc_project/pldm") +
+            sdbusplus::bus::match::rules::interface(
+                "xyz.openbmc_project.PLDM.Event"),
+        std::bind_front(&PLDMSensorEvents::stateSensorCallback, this));
+}
+
+void PLDMSensorEvents::stateSensorCallback(sdbusplus::message::message& msg)
+{
+    uint8_t msgTID;
+    uint16_t msgSensorID;
+    uint8_t msgSensorOffset;
+    uint8_t msgEventState;
+    uint8_t msgPreviousEventState;
+
+    // Read the msg and populate each variable
+    msg.read(msgTID, msgSensorID, msgSensorOffset, msgEventState,
+             msgPreviousEventState);
+
+    if (msgTID == constants::phypTerminusID && msgSensorID == osIPLModeSensorId)
+    {
+        osIPLModeState = msgEventState;
+    }
+}
+
+} // namespace panel

--- a/src/pldm_fw.cpp
+++ b/src/pldm_fw.cpp
@@ -1,5 +1,6 @@
 #include "pldm_fw.hpp"
 
+#include "const.hpp"
 #include "exception.hpp"
 #include "utils.hpp"
 
@@ -114,7 +115,7 @@ void PldmFramework::sendPanelFunctionToPhyp(
     const types::FunctionNumber& funcNumber)
 {
     types::PdrList pdrs =
-        utils::getPDR(phypTerminusID, frontPanelBoardEntityId,
+        utils::getPDR(constants::phypTerminusID, frontPanelBoardEntityId,
                       stateIdToEnablePanelFunc, "FindStateEffecterPDR");
 
     if (pdrs.empty())

--- a/test/panel_state_manager_test.cpp
+++ b/test/panel_state_manager_test.cpp
@@ -1,4 +1,5 @@
 #include "panel_state_manager.hpp"
+#include "pldm_dbus_signals.hpp"
 #include "transport.hpp"
 #include "types.hpp"
 
@@ -24,8 +25,10 @@ auto dummy_conn = std::make_shared<sdbusplus::asio::connection>(*io_con);
 auto iface = std::make_shared<sdbusplus::asio::dbus_interface>(
     dummy_conn, std::string{}, std::string{});
 
+auto dummySensorEvent = std::make_shared<panel::PLDMSensorEvents>();
 auto lcdPanel = std::make_shared<panel::Transport>();
-auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io_con);
+auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io_con,
+                                                  dummySensorEvent);
 
 TEST(PanelStateManager, default_state)
 {


### PR DESCRIPTION
PHYP will present a unique OEM sensor under the
Logical VMM to show the enabled/disabled OS IPL mode
setting. PLDM proposes entity id and state set id to
find the PDR associated with that sensor.

Using the sensor information from PDR, panel sends request
to phyp to fetch the current sensor state value associated
with os ipl mode change event.

Based on the os ipl mode(enabled/disabled), function 01
decides to display OS IPL mode types in lcd panel.

PHYP will enable OS IPL mode only when the service partition
is IBMi. If there isn't a service partition or if the
service partition is aix or linux, phyp disables the os ipl mode.

Test:
Tested on rainier.
Able to get the os ipl mode sensor state value from phyp.

Oct 14 06:59:15 rain98bmc ibm-panel[6575]:  calling pldm base trigger sensor state event
Oct 14 06:59:15 rain98bmc ibm-panel[6575]:  rc of pldm send receive  = 0
Oct 14 06:59:15 rain98bmc pldmd[1136]: Rx: 09 01 00 02 21 00 01 00 02 02 02
Oct 14 06:59:15 rain98bmc ibm-panel[6575]:  response size = 9
Oct 14 06:59:15 rain98bmc ibm-panel[6575]:  rc of decode 0
Oct 14 06:59:15 rain98bmc ibm-panel[6575]: present state = 2
Oct 14 06:59:15 rain98bmc ibm-panel[6575]: previous state = 2

Tested for enabled case by sending the raw sensor signal to bmc via pldm.

pldmtool raw --data 0x80 0x02 0x0A 0x01 0xD0 0x00 0x05 0x00 0x01 0x00 0x02 0x01

Setting the last byte to 0x01 - which is the current sensor state - value ENABLED.

Received the expected response from panel app for this trigger event.

Change-Id: I6456da38e748f089f9e344e88d1170d5086b0613
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>