### PR TITLE
Tool for simulating panel input

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -49,6 +49,10 @@ class BusHandler
         iface->register_property(
             "ACFWindowActive", false,
             sdbusplus::asio::PropertyPermission::readWrite);
+
+       iface->register_method("ProcessButton", [this](int event) {
+            this->btnRequest(event););
+        });
     }
 
   private:
@@ -90,6 +94,14 @@ class BusHandler
 
     /* Pointer to state manager class */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+    /**
+     * @brief Api to process button request.
+     *
+     * @param[in] event: Button event
+     */
+    void btnRequest(int event);
+
 };
 
 } // namespace panel

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,23 @@ panel_app_a = static_library(
     'src/pldm_fw.cpp',
     include_directories: 'include'
 )
+panel_tool_a = static_library(
+     'ibm_dbus_call_a',
+     'tools/src/dbus_call.cpp',
+     include_directories: ['include', 'tools/include']
+)
+executable(
+      'paneltool',
+      'tools/src/panel_tool.cpp',
+      dependencies: [
+        sdbusplus,
+      ],
+      install: true,
+      include_directories : [ 'include', 'tools/include'],
+      link_with: [
+          panel_tool_a,
+      ],
+)
 
 executable(
     'ibm-panel',

--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -47,4 +47,27 @@ void BusHandler::toggleFunctionState(types::FunctionalityList functionBitMap)
     // to disable all the functions.
     stateManager->toggleFuncStateFromPhyp(functionList);
 }
+
+void BusHandler::btnRequest(int event)
+{
+    switch (event)
+    {
+        case 0:
+            stateManager->processPanelButtonEvent(
+                types::ButtonEvent::INCREMENT);
+            break;
+
+        case 1:
+            stateManager->processPanelButtonEvent(
+                types::ButtonEvent::DECREMENT);
+            break;
+
+        case 2:
+            stateManager->processPanelButtonEvent(
+                types::ButtonEvent::EXECUTE);
+            break;
+        default:
+            std::cerr << "Invalid Input" << std::endl;
+    }
+}
 } // namespace panel

--- a/tools/include/dbus_call.hpp
+++ b/tools/include/dbus_call.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+namespace panel
+{
+namespace tool
+{
+
+/**
+ * @brief Api to handle input events.
+ * This api receives input event and call dbus api to process button event
+ * accordingly.
+ * @param[in] input: Input event.
+ *                   It can have values UP/DOWN or EXECUTE.
+ */
+void btnEventDbusCall(const std::string& input);
+
+} // namespace tool
+} // namespace panel

--- a/tools/src/dbus_call.cpp
+++ b/tools/src/dbus_call.cpp
@@ -1,0 +1,47 @@
+#include "dbus_call.hpp"
+
+#include "types.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/exception.hpp>
+
+namespace panel
+{
+namespace tool
+{
+void btnEventDbusCall(const std::string& input)
+{
+    auto param = -1;
+    if ((input.compare("DOWN")) == 0)
+    {
+        param = types::ButtonEvent::DECREMENT;
+    }
+    else if ((input.compare("UP")) == 0)
+    {
+        param = types::ButtonEvent::INCREMENT;
+    }
+    else if ((input.compare("EXECUTE")) == 0)
+    {
+        param = types::ButtonEvent::EXECUTE;
+    }
+    else
+    {
+        throw std::runtime_error("Invalid Input");
+    }
+
+    auto bus = sdbusplus::bus::new_default_system();
+    auto method = bus.new_method_call("com.ibm.PanelApp", "/com/ibm/panel_app",
+                                      "com.ibm.panel", "ProcessButton");
+    method.append(param);
+    try
+    {
+        auto reply = bus.call(method);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cerr << "SDBUS call failed: " << e;
+        throw;
+    }
+}
+} // namespace tool
+} // namespace panel

--- a/tools/src/panel_tool.cpp
+++ b/tools/src/panel_tool.cpp
@@ -1,0 +1,35 @@
+#include "dbus_call.hpp"
+
+#include <CLI/CLI.hpp>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    std::string input{};
+    CLI::App app{"Command line tool for simulating panel functions "};
+    auto state =
+        app.add_option(
+               " -b", input,
+               " Simulating button press"
+               " Increment/Decrement/Execute with UP/DOWN/EXECUTE respectively")
+    CLI11_PARSE(app, argc, argv);
+
+    try
+    {
+        if (*state)
+        {
+            panel::tool::btnEventDbusCall(input);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "One of the valid options is required. Refer "
+                "--help for list of options.");
+        }
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << e.what();
+    }
+    return 0;
+}


### PR DESCRIPTION
This commit implements paneltool exe to simulate panel button
event and panel behaviour corresponding to the input in a
given scenario.

Sample command for up button event:
paneltool -b UP

paneltool --help for more details.

Sample command (Panel at function number 01):
./paneltool -b EXECUTE

output:
L1 : 01     N    PVM
L2 :             T