### PR TITLE
Unwanted logs removed

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -133,11 +133,6 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                       << std::endl;
         }
     }
-    else
-    {
-        std::cerr << "PEL entry not yet created, Ignoring the signal"
-                  << std::endl;
-    }
 }
 
 static void sortPels(types::GetManagedObjects& listOfPels)


### PR DESCRIPTION
The log was logged on every PEL event and was flooding the
journal.
Not neccessary to log this information for every PEL event.
Hence removed.

Change-Id: I401aa27c4d8ed00c77672d0b329ee305491ee8bc
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>