### PR TITLE
Execute function 01 at bmc ready state

### DIFF
--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -871,6 +871,13 @@ void PanelStateManager::updateBMCState(const std::string& bmcState)
     // BMC state is anything other than NotReady
     if (bmcState != "xyz.openbmc_project.State.BMC.BMCState.NotReady")
     {
+        // If BMC state is ready, execute functionality 01.
+        if (bmcState == "xyz.openbmc_project.State.BMC.BMCState.Ready")
+        {
+            // Execute function 01 on bmc ready state.
+            funcExecutor->executeFunction(1, types::FunctionalityList{});
+        }
+
         // if the bit is not set
         if ((systemState & SystemStateMask::ENABLE_BMC_STANDBY_STATE) == 0x00)
         {


### PR DESCRIPTION
As per the requirement, panel code should output function
01 when bmc state is changed to ready.

Change-Id: I65db1928427420835ae23454468355893cbcd581
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>