### PR TITLE
Update parameters for System operating mode

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -245,12 +245,6 @@ class SystemStatus
     void bootProgressStateCallback(sdbusplus::message::message& msg);
 
     /**
-     * @brief Api to handle logging settings state change callback.
-     * @param[in] msg - Callback message.
-     */
-    void loggingSettingStateCallback(sdbusplus::message::message& msg);
-
-    /**
      * @brief Api to handle power policy state change callback.
      * @param[in] msg - Callback message.
      */
@@ -282,9 +276,6 @@ class SystemStatus
 
     /* state manager */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
-
-    /* Member to store logging policy*/
-    bool loggingPolicy;
 
     /* Member to store power policy */
     std::string powerPolicy;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -62,10 +62,6 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
 
 void readSystemOperatingMode(std::string& sysOperatingMode)
 {
-    auto readLogSettings = readBusProperty<std::variant<bool>>(
-        "xyz.openbmc_project.Settings", "/xyz/openbmc_project/logging/settings",
-        "xyz.openbmc_project.Logging.Settings", "QuiesceOnHwError");
-
     auto readRestorePolicy = readBusProperty<std::variant<std::string>>(
         "xyz.openbmc_project.Settings",
         "/xyz/openbmc_project/control/host0/power_restore_policy",
@@ -77,15 +73,12 @@ void readSystemOperatingMode(std::string& sysOperatingMode)
         "/xyz/openbmc_project/control/host0/auto_reboot",
         "xyz.openbmc_project.Control.Boot.RebootPolicy", "AutoReboot");
 
-    const auto loggingService = std::get_if<bool>(&readLogSettings);
     const auto restorePolicy = std::get_if<std::string>(&readRestorePolicy);
     const auto autoRebootPolicy = std::get_if<bool>(&readRebootPolicy);
 
-    if (loggingService != nullptr && restorePolicy != nullptr &&
-        autoRebootPolicy != nullptr)
+    if (restorePolicy != nullptr && autoRebootPolicy != nullptr)
     {
-        if (*loggingService == true &&
-            *restorePolicy == "xyz.openbmc_project.Control.Power."
+        if (*restorePolicy == "xyz.openbmc_project.Control.Power."
                               "RestorePolicy.Policy.AlwaysOff" &&
             *autoRebootPolicy == false)
         {


### PR DESCRIPTION
This commit removes logic to consider property "QuiesceOnHwError"
under logging settings as a parameter to detect system operating
mode.

Change-Id: Ic84b1e882512befa970557e0f8328e6306911dc0
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>