### PR TITLE
Flow update to set current operating mode

### DIFF
--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -1,5 +1,6 @@
 #include "panel_state_manager.hpp"
 
+#include "exception.hpp"
 #include "utils.hpp"
 
 #include <algorithm>
@@ -489,10 +490,32 @@ void PanelStateManager::setIPLParameters(const types::ButtonEvent& button)
                     panelCurSubStates.at(1) != StateType::INVALID_STATE ||
                     panelCurSubStates.at(2) != StateType::INVALID_STATE)
                 {
+                    try
+                    {
+                        funcExecutor->executeFunction(
+                            panelFunctions.at(panelCurState).functionNumber,
+                            panelCurSubStates);
 
-                    funcExecutor->executeFunction(
-                        panelFunctions.at(panelCurState).functionNumber,
-                        panelCurSubStates);
+                        if (panelCurSubStates.at(1) != StateType::INVALID_STATE)
+                        {
+                            if (panelCurSubStates.at(1) == 0)
+                            {
+                                std::cout << "Manual mode set" << std::endl;
+                                setSystemOperatingMode("Manual");
+                            }
+                            else if (panelCurSubStates.at(1) == 1)
+                            {
+                                std::cout << "Normal mode set" << std::endl;
+                                setSystemOperatingMode("Normal");
+                            }
+                        }
+                    }
+                    catch (const sdbusplus::exception::SdBusError& e)
+                    {
+                        std::cerr << "Error writing values to set system "
+                                     "operating mode"
+                                  << std::endl;
+                    }
 
                     // reset all the flag
                     panelCurSubStates.at(0) = StateType::INITIAL_STATE;


### PR DESCRIPTION
This commit implement changes to update panel internal state
for system operating mode right at the time of setting it
from function 02, instead of waiting for the DBus signal to
update the same.

This change was done to avoid any delay which can be there
between setting the mode, signal receiving and processing the
signal callback.

Also, code to set property "QuiesceOnHwError" is removed as
operating mode setting no longer depends on it.

Change-Id: I93025d0bf56ccb4df9faf5bb7b9ae02676ad6b4f
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>