### PR TITLE
Add 3 seconds interval after software reset

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -86,7 +86,7 @@ void Transport::doSoftReset()
 {
     using namespace std::chrono_literals;
     panelI2CWrite(encoder::MessageEncoder().softReset());
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(3000ms);
     std::cout << "\n Panel:Soft reset done." << std::endl;
 }
 


### PR DESCRIPTION
This commit adds logic which increases the interval
time after software reset from 100ms to 3000ms.

This avoids bouncing ball problem after AC cycle/hotplug
and keeps panel in working state.

Tested on rain530. Issue resolved.

Change-Id: I1044d7a83ce33fd25675c268d37be55ab8cb4cab
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>