### PR TITLE
D-bus method to display lines on lcd panel

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -59,8 +59,6 @@ class BusHandler
      *
      * @param[in] displayLine1: 1st line of display.
      * @param[in] displayLine2: 2nd line of display.
-     *
-     *
      */
     void display(const std::string& displayLine1,
                  const std::string& displayLine2);

--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -9,10 +9,7 @@ namespace panel
 void BusHandler::display(const std::string& displayLine1,
                          const std::string& displayLine2)
 {
-    // added cout to escape from unused variable error. can be removed once the
-    // implementation is added.
-    std::cout << displayLine1 << displayLine2 << std::endl;
-    // Implement display function
+    utils::sendCurrDisplayToPanel(displayLine1, displayLine2, transport);
 }
 
 void BusHandler::triggerPanelLampTest(const bool state)


### PR DESCRIPTION
This commit has changes that sends the actual display call
to panel micro controller whenever the "Display" d-bus method
is invoked.

Test:
Tested on rainier.
busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel Display ss L1 L2
Output: This displays L1 and L2 on lcd panel.

Change-Id: Ib6b3d7ae1873b2fd4528d327d447668bb9bf43ca
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>