### PR TITLE
D-bus method to display lines on lcd panel

### DIFF
--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -9,10 +9,7 @@ namespace panel
 void BusHandler::display(const std::string& displayLine1,
                          const std::string& displayLine2)
 {
-    // added cout to escape from unused variable error. can be removed once the
-    // implementation is added.
-    std::cout << displayLine1 << displayLine2 << std::endl;
-    // Implement display function
+    utils::sendCurrDisplayToPanel(displayLine1, displayLine2, transport);
 }
 
 void BusHandler::triggerPanelLampTest(const bool state)


### PR DESCRIPTION
This commit has changes that sends the actual display call
to panel micro controller whenever the "Display" d-bus method
is invoked.