### PR TITLE
Dbus property to store OS IPL mode

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -25,12 +25,14 @@ class BusHandler
      * @param[in] transport - Transport class object.
      * @param[in] iface - Pointer to Panel dbus interface.
      * @param[in] manager - Pointer to state manager.
+     * @param[in] executor - Pointer to executor.
      */
     BusHandler(std::shared_ptr<Transport>& transport,
                std::shared_ptr<sdbusplus::asio::dbus_interface>& iface,
-               std::shared_ptr<state::manager::PanelStateManager>& manager) :
+               std::shared_ptr<state::manager::PanelStateManager>& manager,
+               std::shared_ptr<Executor>& executor) :
         transport(transport),
-        iface(iface), stateManager(manager)
+        iface(iface), stateManager(manager), executor(executor)
     {
         iface->register_method("Display", [this](const std::string& line1,
                                                  const std::string& line2) {
@@ -52,6 +54,18 @@ class BusHandler
 
         iface->register_method("ProcessButton",
                                [this](int event) { this->btnRequest(event); });
+
+        iface->register_property(
+            "OSIPLMode", false,
+            [this, executor](const bool newVal, bool& oldVal) {
+                if (newVal != oldVal)
+                {
+                    executor->setOSIPLMode(newVal);
+                    oldVal = newVal;
+                    return 1;
+                }
+                return 0;
+            });
     }
 
   private:
@@ -93,6 +107,9 @@ class BusHandler
 
     /* Pointer to state manager class */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+    /* Pointer to Executor class */
+    std::shared_ptr<Executor> executor;
 
     /**
      * @brief Api to process button request.

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -108,6 +108,19 @@ class Executor
         return serviceSwitch1State;
     }
 
+    /**
+     * @brief API which sets OS IPL mode.
+     * This api is called whenever there is a property change signal occurs for
+     * OSIPLMode com.ibm.panel interface's property and the current OS IPL mode
+     * value is stored in Executor.
+     *
+     * @param[in] osIPLModeState - current osIPLMode
+     */
+    inline void setOSIPLMode(const bool osIPLModeState)
+    {
+        osIplMode = osIPLModeState;
+    }
+
   private:
     /**
      * @brief An api to execute functionality 20
@@ -205,14 +218,6 @@ class Executor
      */
     std::string getSrcDataForPEL();
 
-    /**
-     * @brief An api of check if OS IPL type is enabled.
-     * It is a helper function for functionality 01. Display needs to be
-     * modified depending upon if OS IPL type is enabled or disabled.
-     * @return OS IPL type enabled/disbaled.
-     */
-    bool isOSIPLTypeEnabled() const;
-
     /** @brief API to execute function 30. */
     void execute30(const types::FunctionalityList& subFuncNumber);
 
@@ -276,6 +281,9 @@ class Executor
 
     /* Event for timer required in function 74 */
     std::shared_ptr<boost::asio::io_context> io_context;
+
+    /* OS IPL mode state */
+    bool osIplMode = false;
 
 }; // class Executor
 } // namespace panel

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -495,13 +495,6 @@ void Executor::execute30(const types::FunctionalityList& subFuncNumber)
     panel::utils::sendCurrDisplayToPanel(line1, line2, transport);
 }
 
-bool Executor::isOSIPLTypeEnabled() const
-{
-    // TODO: Check with PLDM how they will communicate if IPL type is
-    // enabled or disabled. Till then return dummy value as false.
-    return false;
-}
-
 void Executor::execute01()
 {
     const auto sysValues = utils::readSystemParameters();
@@ -509,7 +502,7 @@ void Executor::execute01()
     std::string line1(16, ' ');
     std::string line2(16, ' ');
 
-    if (isOSIPLTypeEnabled())
+    if (osIplMode)
     {
         // OS IPL Type
         line1.replace(4, 1, std::get<0>(sysValues).substr(0, 1));

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -195,7 +195,7 @@ int main(int, char**)
         panel::BootProgressCode progressCode(lcdPanel, conn, executor);
         progressCode.listenProgressCode();
 
-        panel::BusHandler busHandle(lcdPanel, iface, stateManager);
+        panel::BusHandler busHandle(lcdPanel, iface, stateManager, executor);
 
         iface->initialize();
 


### PR DESCRIPTION
This commit has a new dbus property ("OSIPLMode"), present
at com.ibm.panel to store the OS IPL mode state change value.

This property is updated by PLDM whenever the
"PLDM OEM OS IPL MODE" sensor state signal is sent by PHYP.

Tested on rainier.
root@p10bmc:/tmp# busctl get-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel  OSIPLMode
b false
root@p10bmc:/tmp#
root@p10bmc:/tmp# pldmtool raw --data 0x80 0x02 0x0A 0x01 0xD0 0x00 0x05 0x00 0x01 0x00 0x01 0x02
pldmtool: Tx: 08 01 80 02 0a 01 d0 00 05 00 01 00 01 02
pldmtool: Rx: 08 01 00 02 0a 00 00
root@p10bmc:/tmp#
root@p10bmc:/tmp# busctl get-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel  OSIPLMode
b true
root@p10bmc:/tmp#
root@p10bmc:~# paneltool -b EXECUTE
Mar 10 10:33:05 rain71bmc ibm-panel[3360]: L1 : 01  D  N    PVM
Mar 10 10:33:05 rain71bmc ibm-panel[3360]: L2 :             P

root@p10bmc:/tmp# pldmtool raw --data 0x80 0x02 0x0A 0x01 0xD0 0x00 0x05 0x00 0x01 0x00 0x02 0x01
pldmtool: Tx: 08 01 80 02 0a 01 d0 00 05 00 01 00 02 01
pldmtool: Rx: 08 01 00 02 0a 00 00
root@p10bmc:/tmp#
root@p10bmc:/tmp# busctl get-property com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel  OSIPLMode
b false
root@p10bmc:/tmp#
root@p10bmc:~# paneltool -b EXECUTE
Mar 10 10:33:54 rain71bmc ibm-panel[3360]: L1 : 01     N    PVM
Mar 10 10:33:54 rain71bmc ibm-panel[3360]: L2 :             P

Change-Id: I43b522ec30e9f542c47ac89f3f2081b00809485a
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>