### PR TITLE
Display Phyp src and hexwords

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -70,6 +70,18 @@ class Executor
     void storePelEventId(const std::string& pelEventId);
 
     /**
+     * @brief An api to store latest SRC and Hexwords.
+     * This api will receive string consisting SRC and Hexwords and store them
+     * to be used in function 11, 12 and 13.
+     *
+     * @param[in] srcAndHexwords- String consisting of SRC and hex words.
+     */
+    inline void storeSRCAndHexwords(const std::string& srcAndHexwords)
+    {
+        latestSrcAndHexwords = srcAndHexwords;
+    }
+
+    /**
      * @brief An api to return count of Pel EventIds.
      * This count is required to enable/disable sub functions by state manager
      * w.r.t function 64.
@@ -284,6 +296,9 @@ class Executor
 
     /* OS IPL mode state */
     bool osIplMode = false;
+
+    /* SRC and HEX words */
+    std::string latestSrcAndHexwords;
 
 }; // class Executor
 } // namespace panel

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -278,22 +278,21 @@ void Executor::execute20()
 
 void Executor::execute11()
 {
-    auto srcData = pelEventIdQueue.back();
-
-    if (!srcData.empty())
+    if (!latestSrcAndHexwords.empty())
     {
         // find the first space to get response code
-        auto pos = srcData.find_first_of(" ");
+        auto pos = latestSrcAndHexwords.find_first_of(" ");
 
         // length of src data need to be 8
         if (pos != std::string::npos && pos == 8)
         {
-            utils::sendCurrDisplayToPanel((srcData).substr(0, pos),
+            utils::sendCurrDisplayToPanel((latestSrcAndHexwords).substr(0, pos),
                                           std::string{}, transport);
         }
         else
         {
-            std::cerr << "Invalid srcData received = " << srcData << std::endl;
+            std::cerr << "Invalid srcData received = " << latestSrcAndHexwords
+                      << std::endl;
         }
         return;
     }
@@ -549,19 +548,17 @@ void Executor::execute01()
 
 void Executor::execute12()
 {
-    auto srcData = pelEventIdQueue.back();
-
     // Need to show blank spaces in case no srcData as function is enabled.
     constexpr auto blankHexWord = "        ";
     std::vector<std::string> output(4, blankHexWord);
 
-    if (!srcData.empty())
+    if (!latestSrcAndHexwords.empty())
     {
         std::vector<std::string> src;
-        boost::split(src, srcData, boost::is_any_of(" "));
+        boost::split(src, latestSrcAndHexwords, boost::is_any_of(" "));
 
         const auto size = std::min(src.size(), (size_t)5);
-        // ignoring the first hexword
+        // ignoring the first hexword as that will be SRC.
         for (size_t i = 1; i < size; ++i)
         {
             output[i - 1] = src[i];
@@ -575,17 +572,15 @@ void Executor::execute12()
 
 void Executor::execute13()
 {
-    auto srcData = pelEventIdQueue.back();
-
-    // Need to show blank spaces in case of no srcData as function is
+    // Need to show blank spaces in case of no hex word as function is
     // enabled.
     constexpr auto blankHexWord = "        ";
     std::vector<std::string> output(4, blankHexWord);
 
-    if (!srcData.empty())
+    if (!latestSrcAndHexwords.empty())
     {
         std::vector<std::string> src;
-        boost::split(src, srcData, boost::is_any_of(" "));
+        boost::split(src, latestSrcAndHexwords, boost::is_any_of(" "));
 
         const auto size = std::min(src.size(), (size_t)9);
         // ignoring the first five hexword
@@ -863,6 +858,7 @@ void Executor::storePelEventId(const std::string& pelEventId)
         pelEventIdQueue.pop_front();
     }
     pelEventIdQueue.push_back(pelEventId);
+    latestSrcAndHexwords = pelEventId;
 }
 
 void Executor::execute64(const types::FunctionNumber subFuncNumber)


### PR DESCRIPTION
The commit impement changes to store SRC and HEX words
sent down by the phyp to display in function 11 to 13.

Function 11 will be used to display the SRC and function
12 and 13, each  will be used to display maximum of 4 HEX
words.

Change-Id: Idcc8f0f869079b3791747618999e401a4dc30739
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>