### PR TITLE
Clang format missing for an header file

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -55,17 +55,16 @@ class BusHandler
         iface->register_method("ProcessButton",
                                [this](int event) { this->btnRequest(event); });
 
-        iface->register_property(
-            "OSIPLMode", false,
-            [this](const bool newVal, bool& oldVal) {
-                if (newVal != oldVal)
-                {
-                    this->executor->setOSIPLMode(newVal);
-                    oldVal = newVal;
-                    return 1;
-                }
-                return 0;
-            });
+        iface->register_property("OSIPLMode", false,
+                                 [this](const bool newVal, bool& oldVal) {
+                                     if (newVal != oldVal)
+                                     {
+                                         this->executor->setOSIPLMode(newVal);
+                                         oldVal = newVal;
+                                         return 1;
+                                     }
+                                     return 0;
+                                 });
     }
 
   private:


### PR DESCRIPTION
include/bus_handler.hpp is not in clang format due to which
IBM CI fails.

Change-Id: I08e2ce5d7f1883ee66aae4662f04962ce8a7a40b
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>