### PR TITLE
Func30:Pick inventory ethernet objects at runtime

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -176,5 +176,18 @@ types::PdrList getPDR(const uint8_t& terminusId, const uint16_t& entityId,
 void getSensorDataFromPdr(const types::PdrList& stateSensorPdr,
                           uint16_t& sensorId);
 
+/**
+ * @brief Get subtree path for the given interface under given object path.
+ * @param[in] objectPath - Object path to find the subtree for the given
+ * interface.
+ * @param[in] intf - Interface list.
+ * @param[in] depth - Maximum subtree depth to fetch the results.
+ *
+ * @return List of all fru paths categorized under the given interface.
+ */
+std::vector<std::string> getSubTreePaths(const std::string& objectPath,
+                                         const std::vector<std::string>& intf,
+                                         const int32_t depth);
+
 } // namespace utils
 } // namespace panel

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,5 +319,34 @@ void getSensorDataFromPdr(const types::PdrList& stateSensorPdr,
     sensorId = pdr->sensor_id;
 }
 
+std::vector<std::string> getSubTreePaths(const std::string& objectPath,
+                                         const std::vector<std::string>& intf,
+                                         const int32_t depth)
+{
+    std::vector<std::string> result;
+
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto mapperCall = bus.new_method_call(
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths");
+
+        mapperCall.append(objectPath);
+        mapperCall.append(depth);
+        mapperCall.append(intf);
+
+        auto response = bus.call(mapperCall);
+        response.read(result);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        std::cerr << e.what();
+    }
+
+    return result;
+}
+
 } // namespace utils
 } // namespace panel


### PR DESCRIPTION
This commit removes the hardcoded inventory ethernet objects
from the code and instead it takes the objects from dbus at
runtime.

Test:
Tested on rainier. Achieving the expected results.

Change-Id: I507f4c053e31f7eb762ae74c88225b4364fbbe8b
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>