### PR TITLE
Use Bios attribute for boot side

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -126,12 +126,6 @@ void writeBusProperty(const std::string& serviceName,
 }
 
 /**
- * @brief Make mapper call to get boot side paths.
- * @return List of all image object paths.
- */
-std::vector<std::string> getBootSidePaths();
-
-/**
  * @brief Get next marked boot side.
  * @param[out] nextBootSide -  Next selected boot side.
  */

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -171,110 +171,31 @@ types::GetManagedObjects getManagedObjects(const std::string& service,
     return retVal;
 }
 
-std::vector<std::string> getBootSidePaths()
-{
-    std::vector<std::string> result;
-    result.reserve(2);
-
-    auto bus = sdbusplus::bus::new_default();
-    auto mapperCall = bus.new_method_call("xyz.openbmc_project.ObjectMapper",
-                                          "/xyz/openbmc_project/object_mapper",
-                                          "xyz.openbmc_project.ObjectMapper",
-                                          "GetSubTreePaths");
-
-    const int32_t depth = 0;
-    std::vector<std::string> intf{
-        "xyz.openbmc_project.Software.RedundancyPriority"};
-
-    mapperCall.append("/xyz/openbmc_project/software");
-    mapperCall.append(depth);
-    mapperCall.append(intf);
-
-    auto response = bus.call(mapperCall);
-    response.read(result);
-
-    // any bus exception will be caught in state manager.
-    return result;
-}
-
 void getNextBootSide(std::string& nextBootSide)
 {
-    auto bootSidePaths = getBootSidePaths();
+    std::string valueType;
+    std::variant<std::string> bootSideValue;
+    std::variant<std::string> var3;
 
-    // If we do not receive any path or just one path we default current
-    // boot side as "P".
-    if (bootSidePaths.size() == 2)
+    auto bus = sdbusplus::bus::new_default();
+    auto method = bus.new_method_call(
+        "xyz.openbmc_project.BIOSConfigManager",
+        "/xyz/openbmc_project/bios_config/manager",
+        "xyz.openbmc_project.BIOSConfig.Manager", "GetAttribute");
+    method.append("fw_boot_side");
+    auto result = bus.call(method);
+    result.read(valueType, bootSideValue, var3);
+
+    if (auto bootSide = std::get_if<std::string>(&bootSideValue))
     {
-        // get functional framework list
-        auto res =
-            utils::readBusProperty<std::variant<std::vector<std::string>>>(
-                "xyz.openbmc_project.ObjectMapper",
-                "/xyz/openbmc_project/software/functional",
-                "xyz.openbmc_project.Association", "endpoints");
-
-        const auto functionalFw = std::get_if<std::vector<std::string>>(&res);
-        if ((functionalFw == nullptr) || (functionalFw->size() == 0))
+        if (*bootSide == "Perm")
         {
-            // We could not get any functional FW. This should not be a
-            // situation. log error.
-            throw std::runtime_error("Error fetching functionalFw");
-        }
-
-        std::cout << "Functional Image size = " << functionalFw->size()
-                  << std::endl;
-
-        bool runningImageFound = false;
-        std::string runningImagePath{};
-
-        for (const auto& item : *functionalFw)
-        {
-            auto pos =
-                std::find(bootSidePaths.begin(), bootSidePaths.end(), item);
-
-            if (pos != bootSidePaths.end())
-            {
-                runningImagePath = *pos;
-                runningImageFound = true;
-                std::cout << "Running image found" << runningImagePath
-                          << std::endl;
-                break;
-            }
-        }
-
-        if (!runningImageFound)
-        {
-            throw std::runtime_error("Functional fw not found in boot paths");
-        }
-
-        auto resp = utils::readBusProperty<std::variant<uint8_t>>(
-            "xyz.openbmc_project.Software.BMC.Updater", runningImagePath,
-            "xyz.openbmc_project.Software.RedundancyPriority", "Priority");
-
-        if (const auto imagePriority = std::get_if<uint8_t>(&resp);
-            (imagePriority != nullptr))
-        {
-            // implies this is the running image and it is also marked for next
-            // boot.
-            if (*imagePriority == 0)
-            {
-                nextBootSide = "P";
-            }
-            // implies running image is not marked for next boot.
-            else if (*imagePriority == 1)
-            {
-                nextBootSide = "T";
-            }
+            nextBootSide = "P";
         }
         else
         {
-            throw std::runtime_error("Failed to read boot priority property");
+            nextBootSide = "T";
         }
-    }
-    else
-    {
-        std::cout << "Boot side path not equal to 2. Always mark "
-                     "selected side as P"
-                  << std::endl;
     }
 }
 


### PR DESCRIPTION
The commit implement changes to make use of Bois attribute to
check and update next boot side instead of priority field set
for respective image.

This change was required to align with the new change w.r.t.
choosing and updating next boot image.

Change-Id: I7c838f1077845d1747cf51de2973c51f0d9a6d4d
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>