### PR TITLE
PEL addition for ibm panel

### DIFF
--- a/include/button_handler.hpp
+++ b/include/button_handler.hpp
@@ -39,12 +39,14 @@ class ButtonHandler
      * @param[in] io - Boost asio io_context object pointer.
      * @param[in] transport - Transport Object to call transport functions.
      * @param[in] stateManager - State manager object to call
+     * @param[in] i2cBusPath - i2c bus path to communicate with panel.
      * increment/decrement/execute methods.
      */
     ButtonHandler(
         const std::string& path, std::shared_ptr<boost::asio::io_context>& io,
         std::shared_ptr<Transport> transport,
-        std::shared_ptr<state::manager::PanelStateManager> stateManager);
+        std::shared_ptr<state::manager::PanelStateManager> stateManager,
+        const std::string& i2cBusPath);
 
   private:
     /** @brief Api to perform async read operation on the device path.
@@ -76,6 +78,10 @@ class ButtonHandler
 
     /* state manager object to call increment/decrement/execute functions */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+   /* The /dev/ path to the I2C bus that is used to communicate with the panel.
+    * This will be used for callout purposes. */
+   std::string busPath;
 
     /* file descriptor */
     int fd = -1;

--- a/include/const.hpp
+++ b/include/const.hpp
@@ -48,6 +48,12 @@ static constexpr auto terminatingBit = 2;
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;
+static constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
+static constexpr auto loggerCreateInterface =
+                         "xyz.openbmc_project.Logging.Create";
+static constexpr auto mapperObjectPath = "/xyz/openbmc_project/object_mapper";
+static constexpr auto mapperInterface = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto mapperDestination = "xyz.openbmc_project.ObjectMapper";
 
 } // namespace constants
 } // namespace panel

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -45,6 +45,26 @@ T readBusProperty(const std::string& service, const std::string& object,
  */
 std::string binaryToHexString(const types::Binary& val);
 
+/**
+ * @brief Api to create PEL.
+ *
+ * @param[in] errIntf - Error Interface
+ * @param[in] sev -  panel::constants::Severity of Error
+ * @param[in] additionalData - Information of PEL
+ */
+void createPEL(const std::string& errIntf, const std::string& sev,
+               const std::map<std::string, std::string>& additionalData);
+
+/**
+ * @brief Api to get service.
+ *
+ * @param[in] bus - bus input
+ * @param[in] path -  Dbus object path
+ * @param[in] interface - Interface
+ */
+std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
+                       const std::string& interface);
+
 /** @brief Display on panel using transport class api.
  *
  * Method which sends the actual data to the panel's micro code using Transport
@@ -124,6 +144,12 @@ void writeBusProperty(const std::string& serviceName,
         throw;
     }
 }
+
+/**
+ * @brief Make mapper call to get boot side paths.
+ * @return List of all image object paths.
+ */
+std::vector<std::string> getBootSidePaths();
 
 /**
  * @brief Get next marked boot side.

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -178,7 +178,8 @@ int main(int, char**)
         try
         {
             btnHandler = std::make_unique<panel::ButtonHandler>(
-                getInputDevicePath(imValue), io, lcdPanel, stateManager);
+                getInputDevicePath(imValue), io, lcdPanel, stateManager,
+                lcdDevPath);
         }
         catch (const std::runtime_error& e)
         {
@@ -212,5 +213,6 @@ int main(int, char**)
         // failure. We will do that once Everest hardware is ready.
         // https://github.com/ibm-openbmc/ibm-panel/issues/21
     }
-    return 0;
+    // Create the D-Bus invoker class
+    // Create D-Bus signal handler
 }

--- a/src/pldm_fw.cpp
+++ b/src/pldm_fw.cpp
@@ -119,7 +119,13 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (pdrs.empty())
     {
-        throw FunctionFailure("Empty PDR returned for panel entity id.");
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
+            "Empty PDR returned for panel entity id.");
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     types::Byte instance = getInstanceID();
@@ -129,9 +135,13 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (packet.empty())
     {
-        std::cerr << "Pldm packet is empty" << std::endl;
-        throw FunctionFailure(
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
             "pldm:SetStateEffecterStates request message empty");
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     int fd = pldm_open();
@@ -139,7 +149,14 @@ void PldmFramework::sendPanelFunctionToPhyp(
     {
         std::cerr << "pldm_open() failed with error = " << strerror(errno)
                   << std::endl;
-        throw FunctionFailure("pldm: Failed to connect to MCTP socket");
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
+            "pldm: Failed to connect to MCTP socket");
+        additionalData.emplace("ERRNO:", strerror(errno));
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     std::cout << "packet data sent to pldm: ";
@@ -160,9 +177,12 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (rc)
     {
-        std::cerr << "Pldm send failed" << std::endl;
-        throw FunctionFailure(
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
             "pldm: pldm_send failed for panel function trigger.");
+        panel::utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                          "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                          additionalData);
     }
 }
 } // namespace panel

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,3 +1,4 @@
+#include "const.hpp"
 #include "utils.hpp"
 
 #include "exception.hpp"
@@ -21,6 +22,57 @@ std::string binaryToHexString(const types::Binary& val)
             << static_cast<int>(i);
     }
     return oss.str();
+}
+
+void createPEL(const std::string& errIntf, const std::string& sev,
+               const std::map<std::string, std::string>& additionalData)
+{
+    try
+    {
+        auto bus = sdbusplus::bus::new_default();
+        auto service = getService(bus, constants::loggerObjectPath,
+                       constants::loggerCreateInterface);
+        auto method = bus.new_method_call(service.c_str(),
+                                      constants::loggerObjectPath,
+                                      constants::loggerCreateInterface,
+                                      "Create");
+
+        method.append(errIntf, sev, additionalData);
+        bus.call(method);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        std::cerr<<
+          "Error in invoking D-Bus logging create interface to register PEL";
+    }
+}
+
+std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
+                       const std::string& interface)
+{
+    auto mapper = bus.new_method_call(constants::mapperDestination,
+                                      constants::mapperObjectPath,
+                                      constants::mapperInterface,
+                                      "GetObject");
+    mapper.append(path, std::vector<std::string>({interface}));
+
+    std::map<std::string, std::vector<std::string>> response;
+    try
+    {
+        auto reply = bus.call(mapper);
+        reply.read(response);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        throw std::runtime_error("Service name is not found");
+    }
+
+    if (response.empty())
+    {
+        throw std::runtime_error("Service name response is empty");
+    }
+
+    return response.begin()->first;
 }
 
 void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,


### PR DESCRIPTION
Creation of PELs wherever it's necessary in panel code will
identify the errors and helps in debugging issues faced by
users in ibm op-panel

Test update:
Success opening and accessing the device path: /dev/i2c-7

Success opening and accessing the device path: /dev/i2c-3

Transport key is set to 1 for the panel at /dev/i2c-3, Z

 Panel:Soft reset done.

 Button configuration done.

Transport key is set to 1 for the panel at /dev/i2c-7, Z
System operating mode set to Normal

root@ever10bmc:~# peltool -l
{
    "0x500036EB": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x500036EB",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/10/2022 04:41:46",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    }
}
root@ever10bmc:~# peltool -l
{
    "0x50003734": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x50003734",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/12/2022 10:59:11",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    },
    "0x50003735": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x50003735",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/12/2022 10:59:11",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    }
}

root@ever10bmc:~# peltool -i 0x50003737
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x5000",
    "Created at":               "05/12/2022 11:13:15",
    "Committed at":             "05/12/2022 11:13:16",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50003737",
    "Entry Id":                 "0x50003737",
    "BMC Event Log Id":         "965"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "0x2000",
    "Subsystem":                "CEC Hardware - Operator Panel",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x5000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Power Control Net Fault":  "False",
    "Backplane CCIN":           "2E33",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Unable to open device path or ioctl
failure"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD595002",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E330010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Reporting Machine Type":   "9040-MRX",
    "Reporting Serial Number":  "13E8D4X",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1020.00-39.3",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD595002_2E330010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Machine Type Model":       "9040-MRX",
    "Serial Number":            "13E8D4X"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "NotReady",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1020.00-39.3-16-g579c96cef-dirty",
    "HostState": "Off",
    "System IM": "50003000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_IIC_ADDR": "0x5A",
    "CALLOUT_IIC_BUS": "/dev/i2c-28",
    "DESCRIPTION": " "
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "PEL Internal Debug Data": {
        "SRC": [
            "Problem looking up I2C callouts on 28 90:
[json.exception.out_of_range.403] key '28' not found"
        ]
    }
}
}