### PR TITLE
Update progress code at standby

### DIFF
--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -1,5 +1,6 @@
 #include "panel_state_manager.hpp"
 
+#include "const.hpp"
 #include "exception.hpp"
 #include "utils.hpp"
 
@@ -955,7 +956,18 @@ void PanelStateManager::updatePowerState(const std::string& powerState)
         // unset the bit
         systemState &= SystemStateMask::DISABLE_POWER_STATE;
         updateFunctionStatus();
-        // default function displayed when we power down.
+
+        // As this property is not updated while power off currently, we need to
+        // update progress code at poweroff to ASCII 0 so that HMC can clear
+        // standby state.
+        utils::writeBusProperty<std::tuple<uint64_t, std::vector<uint8_t>>>(
+            "xyz.openbmc_project.State.Boot.Raw",
+            "/xyz/openbmc_project/state/boot/raw0",
+            "xyz.openbmc_project.State.Boot.Raw", "Value",
+            std::make_tuple(constants::clearDisplayProgressCode,
+                            std::vector<uint8_t>{0}));
+
+        //  default function displayed when we power down.
         funcExecutor->executeFunction(1, types::FunctionalityList{});
     }
 }


### PR DESCRIPTION
Boot progress code at is updated to ASCII "000000" at power
off state.
The change was required as HMC shows standby at poweroff
state. Setting the value will enable HMC to clear standby
state.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>