### PR TITLE
PEL addition for ibm panel

### DIFF
--- a/include/button_handler.hpp
+++ b/include/button_handler.hpp
@@ -39,12 +39,14 @@ class ButtonHandler
      * @param[in] io - Boost asio io_context object pointer.
      * @param[in] transport - Transport Object to call transport functions.
      * @param[in] stateManager - State manager object to call
+     * @param[in] i2cBusPath - i2c bus path to communicate with panel.
      * increment/decrement/execute methods.
      */
     ButtonHandler(
         const std::string& path, std::shared_ptr<boost::asio::io_context>& io,
         std::shared_ptr<Transport> transport,
-        std::shared_ptr<state::manager::PanelStateManager> stateManager);
+        std::shared_ptr<state::manager::PanelStateManager> stateManager,
+        const std::string& i2cBusPath);
 
   private:
     /** @brief Api to perform async read operation on the device path.
@@ -76,6 +78,10 @@ class ButtonHandler
 
     /* state manager object to call increment/decrement/execute functions */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+    /* The /dev/ path to the I2C bus that is used to communicate with the panel.
+     * This will be used for callout purposes.*/
+    std::string busPath;
 
     /* file descriptor */
     int fd = -1;

--- a/include/const.hpp
+++ b/include/const.hpp
@@ -48,6 +48,12 @@ static constexpr auto terminatingBit = 2;
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;
+static constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
+static constexpr auto loggerCreateInterface =
+    "xyz.openbmc_project.Logging.Create";
+static constexpr auto mapperObjectPath = "/xyz/openbmc_project/object_mapper";
+static constexpr auto mapperInterface = "xyz.openbmc_project.ObjectMapper";
+static constexpr auto mapperDestination = "xyz.openbmc_project.ObjectMapper";
 
 } // namespace constants
 } // namespace panel

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -45,6 +45,26 @@ T readBusProperty(const std::string& service, const std::string& object,
  */
 std::string binaryToHexString(const types::Binary& val);
 
+/**
+ * @brief Api to create PEL.
+ *
+ * @param[in] errIntf - Error Interface
+ * @param[in] sev -  panel::constants::Severity of Error
+ * @param[in] additionalData - Information of PEL
+ */
+void createPEL(const std::string& errIntf, const std::string& sev,
+               const std::map<std::string, std::string>& additionalData);
+
+/**
+ * @brief Api to get service.
+ *
+ * @param[in] bus - bus input
+ * @param[in] path -  Dbus object path
+ * @param[in] interface - Interface
+ */
+std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
+                       const std::string& interface);
+
 /** @brief Display on panel using transport class api.
  *
  * Method which sends the actual data to the panel's micro code using Transport

--- a/src/button_handler.cpp
+++ b/src/button_handler.cpp
@@ -1,6 +1,8 @@
 #include "button_handler.hpp"
 
+#include "const.hpp"
 #include "panel_state_manager.hpp"
+#include "utils.hpp"
 
 #include <assert.h>
 
@@ -13,9 +15,10 @@ namespace panel
 ButtonHandler::ButtonHandler(
     const std::string& path, std::shared_ptr<boost::asio::io_context>& io,
     std::shared_ptr<Transport> transport,
-    std::shared_ptr<state::manager::PanelStateManager> stateManager) :
+    std::shared_ptr<state::manager::PanelStateManager> stateManager,
+    const std::string& busPath) :
     devicePath(path),
-    io(io), transport(transport), stateManager(stateManager)
+    io(io), transport(transport), stateManager(stateManager), busPath(busPath)
 {
     // TODO update this to actual size needed.
     ipEvent.resize(10);
@@ -27,6 +30,18 @@ ButtonHandler::ButtonHandler(
 
         if (fd < 0)
         {
+            std::map<std::string, std::string> additionalData{};
+            additionalData.emplace("CALLOUT_ERRNO", std::to_string(errno));
+            additionalData.emplace(
+                "DESCRIPTION", "Failed to open the I2C button handler device");
+            additionalData.emplace("CALLOUT_IIC_BUS", busPath);
+            additionalData.emplace("CALLOUT_IIC_ADDR",
+                                   std::to_string(constants::devAddr));
+
+            utils::createPEL("com.ibm.Panel.Error.InputDevPathFailure",
+                             "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                             additionalData);
+
             throw std::runtime_error("Failed to open the input path. Button "
                                      "handler creation failed");
         }

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -178,7 +178,8 @@ int main(int, char**)
         try
         {
             btnHandler = std::make_unique<panel::ButtonHandler>(
-                getInputDevicePath(imValue), io, lcdPanel, stateManager);
+                getInputDevicePath(imValue), io, lcdPanel, stateManager,
+                lcdDevPath);
         }
         catch (const std::runtime_error& e)
         {

--- a/src/pldm_fw.cpp
+++ b/src/pldm_fw.cpp
@@ -119,7 +119,13 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (pdrs.empty())
     {
-        throw FunctionFailure("Empty PDR returned for panel entity id.");
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
+                               "Empty PDR returned for panel entity id.");
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     types::Byte instance = getInstanceID();
@@ -129,9 +135,13 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (packet.empty())
     {
-        std::cerr << "Pldm packet is empty" << std::endl;
-        throw FunctionFailure(
-            "pldm:SetStateEffecterStates request message empty");
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace(
+            "DESCRIPTION", "pldm:SetStateEffecterStates request message empty");
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     int fd = pldm_open();
@@ -139,7 +149,14 @@ void PldmFramework::sendPanelFunctionToPhyp(
     {
         std::cerr << "pldm_open() failed with error = " << strerror(errno)
                   << std::endl;
-        throw FunctionFailure("pldm: Failed to connect to MCTP socket");
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace("DESCRIPTION",
+                               "pldm: Failed to connect to MCTP socket");
+        additionalData.emplace("ERRNO:", strerror(errno));
+        utils::createPEL("com.ibm.Panel.Error.HostCommunicationError",
+                         "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                         additionalData);
+        return;
     }
 
     std::cout << "packet data sent to pldm: ";
@@ -160,9 +177,13 @@ void PldmFramework::sendPanelFunctionToPhyp(
 
     if (rc)
     {
-        std::cerr << "Pldm send failed" << std::endl;
-        throw FunctionFailure(
+        std::map<std::string, std::string> additionalData{};
+        additionalData.emplace(
+            "DESCRIPTION",
             "pldm: pldm_send failed for panel function trigger.");
+        panel::utils::createPEL(
+            "com.ibm.Panel.Error.HostCommunicationError",
+            "xyz.openbmc_project.Logging.Entry.Level.Warning", additionalData);
     }
 }
 } // namespace panel

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1,6 +1,7 @@
 #include "transport.hpp"
 
 #include "i2c_message_encoder.hpp"
+#include "utils.hpp"
 
 #include <fcntl.h>
 #include <linux/i2c-dev.h>
@@ -8,12 +9,15 @@
 
 #include <chrono>
 #include <cstring>
+#include <sstream>
 #include <thread>
 
 namespace panel
 {
 void Transport::panelI2CSetup()
 {
+    std::ostringstream i2cAddress;
+    i2cAddress << "0x" << std::hex << std::uppercase << devAddress;
     if ((panelFileDescriptor = open(devPath.data(), O_WRONLY | O_NONBLOCK)) ==
         -1) // open failure
     {
@@ -22,6 +26,15 @@ void Transport::panelI2CSetup()
         error += std::to_string(err);
         error += "Errno description : ";
         error += strerror(err);
+        error += " for device path ";
+        error += devPath;
+        std::map<std::string, std::string> additionData{};
+        additionData.emplace("DESCRIPTION", error);
+        additionData.emplace("CALLOUT_IIC_BUS", devPath);
+        additionData.emplace("CALLOUT_IIC_ADDR", i2cAddress.str());
+        panel::utils::createPEL(
+            "com.ibm.Panel.Error.I2CSetupFailure",
+            "xyz.openbmc_project.Logging.Entry.Level.Warning", additionData);
         throw std::runtime_error(error);
     }
     if (ioctl(panelFileDescriptor, I2C_SLAVE, devAddress) ==
@@ -36,14 +49,23 @@ void Transport::panelI2CSetup()
         error += std::to_string(err);
         error += ". Errno description : ";
         error += strerror(err);
+        std::map<std::string, std::string> additionData{};
+        additionData.emplace("DESCRIPTION", error);
+        additionData.emplace("CALLOUT_IIC_BUS", devPath);
+        additionData.emplace("CALLOUT_IIC_ADDR", i2cAddress.str());
+        panel::utils::createPEL(
+            "com.ibm.Panel.Error.I2CSetupFailure",
+            "xyz.openbmc_project.Logging.Entry.Level.Warning", additionData);
         throw std::runtime_error(error);
     }
-    std::cout << "\nSuccess opening and accessing the device path: " << devPath
+    std::cout << "Success opening and accessing the device path: " << devPath
               << std::endl;
 }
 
 void Transport::panelI2CWrite(const types::Binary& buffer) const
 {
+    std::ostringstream i2cAddress;
+    i2cAddress << "0x" << std::hex << std::uppercase << devAddress;
     if (transportKey)
     {
         if (buffer.size()) // check if the given buffer has data in it.
@@ -61,6 +83,16 @@ void Transport::panelI2CWrite(const types::Binary& buffer) const
                               << ". Bytes written = " << returnedSize
                               << ". Actual Bytes = " << buffer.size()
                               << ". Retry = " << retryLoop << std::endl;
+                    std::map<std::string, std::string> additionData{};
+                    additionData.emplace("DESCRIPTION", strerror(errno));
+                    additionData.emplace("CALLOUT_IIC_BUS", devPath);
+                    additionData.emplace("CALLOUT_IIC_ADDR", i2cAddress.str());
+                    additionData.emplace("CALLOUT_ERRNO",
+                                         std::to_string(errno));
+                    panel::utils::createPEL(
+                        "xyz.openbmc_project.Common.Device.Error.WriteFailure",
+                        "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                        additionData);
                     continue;
                 }
                 break;


### PR DESCRIPTION
Creation of PELs wherever it's necessary in panel code will
identify the errors and helps in debugging issues faced by
users in ibm op-panel

Test update:
Success opening and accessing the device path: /dev/i2c-7

Success opening and accessing the device path: /dev/i2c-3

Transport key is set to 1 for the panel at /dev/i2c-3, Z

 Panel:Soft reset done.

 Button configuration done.

Transport key is set to 1 for the panel at /dev/i2c-7, Z
System operating mode set to Normal

root@ever10bmc:~# peltool -l
{
    "0x500036EB": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x500036EB",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/10/2022 04:41:46",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    }
}
root@ever10bmc:~# peltool -l
{
    "0x50003734": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x50003734",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/12/2022 10:59:11",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    },
    "0x50003735": {
        "SRC":                  "BD595002",
        "Message":              "Unable to open device path or ioctl
failure",
        "PLID":                 "0x50003735",
        "CreatorID":            "BMC",
        "Subsystem":            "CEC Hardware - Operator Panel",
        "Commit Time":          "05/12/2022 10:59:11",
        "Sev":                  "Predictive Error",
        "CompID":               "0x5000"
    }
}

root@ever10bmc:~# peltool -i 0x50003737
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x5000",
    "Created at":               "05/12/2022 11:13:15",
    "Committed at":             "05/12/2022 11:13:16",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50003737",
    "Entry Id":                 "0x50003737",
    "BMC Event Log Id":         "965"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "0x2000",
    "Subsystem":                "CEC Hardware - Operator Panel",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x5000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Power Control Net Fault":  "False",
    "Backplane CCIN":           "2E33",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Unable to open device path or ioctl
failure"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD595002",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E330010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Reporting Machine Type":   "9040-MRX",
    "Reporting Serial Number":  "13E8D4X",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1020.00-39.3",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD595002_2E330010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Machine Type Model":       "9040-MRX",
    "Serial Number":            "13E8D4X"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCState": "NotReady",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1020.00-39.3-16-g579c96cef-dirty",
    "HostState": "Off",
    "System IM": "50003000"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_IIC_ADDR": "0x5A",
    "CALLOUT_IIC_BUS": "/dev/i2c-28",
    "DESCRIPTION": " "
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "PEL Internal Debug Data": {
        "SRC": [
            "Problem looking up I2C callouts on 28 90:
[json.exception.out_of_range.403] key '28' not found"
        ]
    }
}
}

Change-Id: I5dc830c6688bb26ca434a513143cb1d6f3ff6070