### PR TITLE
transport: Recover From Bootloader Hang

### DIFF
--- a/include/i2c_message_encoder.hpp
+++ b/include/i2c_message_encoder.hpp
@@ -105,11 +105,18 @@ class MessageEncoder
     Binary softReset();
 
     /** @brief Flash Update command encode api
-     * The encoded data packet contains the command code of flash update(0xFF3)
+     * The encoded data packet contains the command code of flash update(0xFF30)
      * and the calculated checksum.
      * @return Encoded data packet of flash update command.
      */
     Binary flashUpdate();
+
+    /** @brief Jump from bootloader to main program
+     * The encoded data packet contains the command code of jumping to main
+     * program (0xFF25) and the calculated checksum.
+     * @return Encoded data packet of jump to main program command.
+     */
+    Binary jumpToMainProgram();
 
     /** @brief Display version command encode api
      * The encoded data packet contains the command code of display version

--- a/include/transport.hpp
+++ b/include/transport.hpp
@@ -108,5 +108,14 @@ class Transport
      * soft reset operation.
      */
     void doSoftReset();
+
+    /**
+     * @brief API to get the panel out of a bootloader hang
+     *
+     * Due to a bug in some levels of the microcode, the panel can sometimes be
+     * stuck in the bootloader. This API attempts to recover from the situation
+     * by forcing the bootloader to jump to the main panel program.
+     */
+    void checkAndFixBootLoaderBug();
 };
 } // namespace panel

--- a/src/i2c_message_encoder.cpp
+++ b/src/i2c_message_encoder.cpp
@@ -119,6 +119,16 @@ Binary MessageEncoder::flashUpdate()
     return encodedData;
 }
 
+Binary MessageEncoder::jumpToMainProgram()
+{
+    Binary encodedData;
+    encodedData.reserve(3);
+    encodedData.emplace_back(0xFF);
+    encodedData.emplace_back(0x25);
+    calculateCheckSum(encodedData);
+    return encodedData;
+}
+
 Binary MessageEncoder::displayVersionCmd()
 {
     Binary encodedData;


### PR DESCRIPTION
This commit implements a workaround for an issue seen with certain
versions of the panel microcode's bootloader. Due to a bug, the
bootloader can sometimes get stuck and not handover to the main panel
application.

This renders the panel unusable (applies to both LCD and bootfail
microcode). I2C to the PIC still works and the bootloader has the
capability to jump to the main program if sent the right I2C command:
0xFF25...

This commit checks if the PIC is stuck in the bootloader whenever we
enable the transport class for the respective PIC. It reads the version
off of the PIC. The bootloader returns a unique version string: "BL".

In case we find the PIC is stuck, we send it the I2C command to jump
over to the main program.

Tested: Tested on a Rainier system by forcing the PIC into the
bootloader and then running the panel app. Verified that the recovery
succeeds and we are able to get the PIC to jump to the main program.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>