### PR TITLE
Fix write Error displays when Hot-plugging the panel out

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <const.hpp>
 #include <sdbusplus/asio/object_server.hpp>
 #include <sstream>
 #include <string>
@@ -9,6 +10,20 @@ namespace panel
 {
 namespace utils
 {
+static types::PanelDataMap lcdDataMap = {
+    {constants::rain2s2uIM,
+     {constants::rainLcdDevPath, constants::devAddr,
+      constants::rainLcdDbusObj}},
+    {constants::rain2s4uIM,
+     {constants::rainLcdDevPath, constants::devAddr,
+      constants::rainLcdDbusObj}},
+    {constants::rain1s4uIM,
+     {constants::rainLcdDevPath, constants::devAddr,
+      constants::rainLcdDbusObj}},
+    {constants::everestIM,
+     {constants::everLcdDevPath, constants::devAddr,
+      constants::everLcdDbusObj}}};
+
 /** @brief Read inventory manager properties from dbus.
  * @param[in] service - Dbus service name
  * @param[in] obj - Dbus object to query for the property.
@@ -202,6 +217,24 @@ void getSensorDataFromPdr(const types::PdrList& stateSensorPdr,
 std::vector<std::string> getSubTreePaths(const std::string& objectPath,
                                          const std::vector<std::string>& intf,
                                          const int32_t depth);
+
+/**
+ * @brief Get the systems IM value.
+ *
+ * @return the IM value of the system.
+ */
+std::string getSystemIM();
+
+/**
+ * @brief Get the presence of the LCD panel.
+ * This api returns the value of the present property
+ * for the LCD panel on the system interface.
+ *
+ * @param[in] imValue - IM value of the system.
+ *
+ * @return The value of the presence property.
+ */
+bool getLcdPanelPresentProperty(const std::string& imValue);
 
 } // namespace utils
 } // namespace panel

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -23,36 +23,6 @@ panel::types::PanelDataMap baseDataMap = {
      {panel::constants::baseDevPath, panel::constants::devAddr,
       panel::constants::everBaseDbusObj}}};
 
-panel::types::PanelDataMap lcdDataMap = {
-    {panel::constants::rain2s2uIM,
-     {panel::constants::rainLcdDevPath, panel::constants::devAddr,
-      panel::constants::rainLcdDbusObj}},
-    {panel::constants::rain2s4uIM,
-     {panel::constants::rainLcdDevPath, panel::constants::devAddr,
-      panel::constants::rainLcdDbusObj}},
-    {panel::constants::rain1s4uIM,
-     {panel::constants::rainLcdDevPath, panel::constants::devAddr,
-      panel::constants::rainLcdDbusObj}},
-    {panel::constants::everestIM,
-     {panel::constants::everLcdDevPath, panel::constants::devAddr,
-      panel::constants::everLcdDbusObj}}};
-
-std::string getIM()
-{
-    auto im = panel::utils::readBusProperty<std::variant<panel::types::Binary>>(
-        panel::constants::inventoryManagerIntf, panel::constants::systemDbusObj,
-        panel::constants::imInterface, panel::constants::imKeyword);
-    if (auto imVector = std::get_if<panel::types::Binary>(&im))
-    {
-        return panel::utils::binaryToHexString(*imVector);
-    }
-    else
-    {
-        std::cerr << "\n Failed querying IM property from dbus" << std::endl;
-    }
-    return "";
-}
-
 std::string getInputDevicePath(const std::string& imValue)
 {
     if (imValue == panel::constants::rain2s2uIM ||
@@ -70,38 +40,23 @@ std::string getInputDevicePath(const std::string& imValue)
     return "/dev/input/by-path/platform-1e78a080.i2c-bus-event-joystick";
 }
 
-bool getPresentProperty(const std::string& imValue)
-{
-    auto present = panel::utils::readBusProperty<std::variant<bool>>(
-        panel::constants::inventoryManagerIntf,
-        std::get<2>((lcdDataMap.find(imValue))->second),
-        panel::constants::itemInterface, "Present");
-    if (auto p = std::get_if<bool>(&present))
-    {
-        return *p;
-    }
-    else
-    {
-        std::cerr << "\n Failed querying Present property from dbus."
-                  << std::endl;
-    }
-    return false;
-}
-
 void getLcdDeviceData(std::string& lcdDevPath, uint8_t& lcdDevAddr,
                       std::string& lcdObjPath, const std::string& imValue)
 {
-    if (lcdDataMap.find(imValue) ==
-        lcdDataMap.end()) // assume the system is tacoma
+    if (panel::utils::lcdDataMap.find(imValue) ==
+        panel::utils::lcdDataMap.end()) // assume the system is tacoma
     {
         lcdDevPath = panel::constants::tacomaLcdDevPath;
         lcdDevAddr = panel::constants::devAddr;
     }
     else
     {
-        lcdDevPath = std::get<0>((lcdDataMap.find(imValue))->second);
-        lcdDevAddr = std::get<1>((lcdDataMap.find(imValue))->second);
-        lcdObjPath = std::get<2>((lcdDataMap.find(imValue))->second);
+        lcdDevPath =
+            std::get<0>((panel::utils::lcdDataMap.find(imValue))->second);
+        lcdDevAddr =
+            std::get<1>((panel::utils::lcdDataMap.find(imValue))->second);
+        lcdObjPath =
+            std::get<2>((panel::utils::lcdDataMap.find(imValue))->second);
     }
 }
 
@@ -118,7 +73,7 @@ int main(int, char**)
         std::shared_ptr<sdbusplus::asio::dbus_interface> iface =
             server.add_interface("/com/ibm/panel_app", "com.ibm.panel");
 
-        const std::string imValue = getIM();
+        const std::string imValue = panel::utils::getSystemIM();
 
         std::string lcdDevPath{}, lcdObjPath{};
         uint8_t lcdDevAddr;
@@ -142,7 +97,8 @@ int main(int, char**)
         // Listen to lcd panel presence always for both rainier and everest
         std::unique_ptr<panel::PanelPresence> presence;
 
-        if (lcdDataMap.find(imValue) != lcdDataMap.end())
+        if (panel::utils::lcdDataMap.find(imValue) !=
+            panel::utils::lcdDataMap.end())
         {
             presence = std::make_unique<panel::PanelPresence>(lcdObjPath, conn,
                                                               lcdPanel);
@@ -155,7 +111,8 @@ int main(int, char**)
              * change from false to true; but the transport key is still
              * true(unchanged). To maintain data accuracy get the "Present"
              * property from dbus and set the transport key again.*/
-            lcdPanel->setTransportKey(getPresentProperty(imValue));
+            lcdPanel->setTransportKey(
+                panel::utils::getLcdPanelPresentProperty(imValue));
         }
         else
         {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -74,32 +74,52 @@ void Transport::panelI2CWrite(const types::Binary& buffer) const
     {
         if (buffer.size()) // check if the given buffer has data in it.
         {
-            static constexpr auto maxRetry = 5; // Just a random value
+            ssize_t returnedSize = 0;
+            int retriesDone = 0;
+            bool writeFailed = false;
+            int failedErrno = 0;
+            static constexpr auto maxRetry = 6; // Just a random value
             for (auto retryLoop = 0; retryLoop < maxRetry; ++retryLoop)
             {
-                auto returnedSize =
+                retriesDone = retryLoop;
+                writeFailed = false;
+                returnedSize =
                     write(panelFileDescriptor, buffer.data(), buffer.size());
                 if (returnedSize !=
                     static_cast<int>(buffer.size())) // write failure
                 {
-                    auto err = errno;
-                    std::cerr << "\n I2C Write failure. Errno : " << err
-                              << ". Errno description : " << strerror(err)
-                              << ". Bytes written = " << returnedSize
-                              << ". Actual Bytes = " << buffer.size()
-                              << ". Retry = " << retryLoop << std::endl;
-                    std::map<std::string, std::string> additionData{};
-                    additionData.emplace("DESCRIPTION", strerror(err));
-                    additionData.emplace("CALLOUT_IIC_BUS", devPath);
-                    additionData.emplace("CALLOUT_IIC_ADDR", i2cAddress.str());
-                    additionData.emplace("CALLOUT_ERRNO", std::to_string(err));
-                    panel::utils::createPEL(
-                        "xyz.openbmc_project.Common.Device.Error.WriteFailure",
-                        "xyz.openbmc_project.Logging.Entry.Level.Warning",
-                        additionData);
-                    continue;
+                    writeFailed = true;
+                    failedErrno = errno;
+                    sleep(1);
+                    const std::string imValue = utils::getSystemIM();
+                    if (false == utils::getLcdPanelPresentProperty(imValue))
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        continue;
+                    }
                 }
                 break;
+            }
+            if (writeFailed == true)
+            {
+                std::cerr << "\n I2C Write failure. Errno : " << failedErrno
+                          << ". Errno description : " << strerror(failedErrno)
+                          << ". Bytes written = " << returnedSize
+                          << ". Actual Bytes = " << buffer.size()
+                          << ". Retry = " << retriesDone << std::endl;
+                std::map<std::string, std::string> additionData{};
+                additionData.emplace("DESCRIPTION", strerror(failedErrno));
+                additionData.emplace("CALLOUT_IIC_BUS", devPath);
+                additionData.emplace("CALLOUT_IIC_ADDR", i2cAddress.str());
+                additionData.emplace("CALLOUT_ERRNO",
+                                     std::to_string(failedErrno));
+                panel::utils::createPEL(
+                    "xyz.openbmc_project.Common.Device.Error.WriteFailure",
+                    "xyz.openbmc_project.Logging.Entry.Level.Warning",
+                    additionData);
             }
         }
         else

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,5 +319,39 @@ std::vector<std::string> getSubTreePaths(const std::string& objectPath,
     return result;
 }
 
+std::string getSystemIM()
+{
+    auto im = readBusProperty<std::variant<types::Binary>>(
+        constants::inventoryManagerIntf, constants::systemDbusObj,
+        constants::imInterface, constants::imKeyword);
+    if (auto imVector = std::get_if<types::Binary>(&im))
+    {
+        return utils::binaryToHexString(*imVector);
+    }
+    else
+    {
+        std::cerr << "\n Failed querying IM property from dbus" << std::endl;
+    }
+    return "";
+}
+
+bool getLcdPanelPresentProperty(const std::string& imValue)
+{
+    auto present = readBusProperty<std::variant<bool>>(
+        constants::inventoryManagerIntf,
+        std::get<2>((lcdDataMap.find(imValue))->second),
+        constants::itemInterface, "Present");
+    if (auto p = std::get_if<bool>(&present))
+    {
+        return *p;
+    }
+    else
+    {
+        std::cerr << "\n Failed querying Present property from dbus."
+                  << std::endl;
+    }
+    return false;
+}
+
 } // namespace utils
 } // namespace panel


### PR DESCRIPTION
Since we have a 5 second presence checker , we can check the
write failure within 5 second intervals so as to see if the
write failure has happened during the Hot plugging out of
the panel or not. If so we do not log that error.

Signed-off-by: Jinu Joy Thomas <jinu.joy.thomas@in.ibm.com>