### PR TITLE
Display default function after panel hotplug

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -31,9 +31,10 @@ class PanelPresence
      */
     PanelPresence(std::string& objPath,
                   std::shared_ptr<sdbusplus::asio::connection> conn,
-                  std::shared_ptr<Transport> transport) :
+                  std::shared_ptr<Transport> transport,
+                  std::shared_ptr<state::manager::PanelStateManager> state) :
         objectPath(objPath),
-        conn(conn), transport(transport)
+        conn(conn), transport(transport), stateManager(state)
     {
     }
 
@@ -47,6 +48,7 @@ class PanelPresence
     std::string objectPath;
     std::shared_ptr<sdbusplus::asio::connection> conn;
     std::shared_ptr<Transport> transport;
+    std::shared_ptr<state::manager::PanelStateManager> stateManager;
 
     /** @brief Read panel's "Present" property and set the transport key.
      * @param[in] msg - pointer to the msg sent by the PropertiesChanged signal.

--- a/include/transport.hpp
+++ b/include/transport.hpp
@@ -75,6 +75,14 @@ class Transport
         return transportKey;
     }
 
+    /** @brief Method to get panel type
+     * @return panel type(LCD/BASE)
+     */
+    inline types::PanelType getPanelType() const
+    {
+        return panelType;
+    }
+
   private:
     /** @brief The panel's file descriptor */
     int panelFileDescriptor = -1;

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -25,6 +25,29 @@ void PanelPresence::readPresentProperty(sdbusplus::message::message& msg)
         if (auto present = std::get_if<bool>(&(itr->second)))
         {
             transport->setTransportKey(*present);
+            if (transport->getPanelType() == types::PanelType::LCD && *present)
+            {
+
+                const auto bmcState =
+                    utils::readBusProperty<std::variant<std::string>>(
+                        "xyz.openbmc_project.State.BMC",
+                        "/xyz/openbmc_project/state/bmc0",
+                        "xyz.openbmc_project.State.BMC", "CurrentBMCState");
+
+                if (const auto* bmc = std::get_if<std::string>(&bmcState))
+                {
+                    if (*bmc == "xyz.openbmc_project.State.BMC.BMCState.Ready")
+                    {
+                        stateManager->updateBMCState(*bmc);
+                    }
+                }
+                else
+                {
+                    std::cerr
+                        << "Failed reading CurrentBMCState property from D-Bus."
+                        << std::endl;
+                }
+            }
         }
         else
         {

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -83,6 +83,14 @@ int main(int, char**)
         auto lcdPanel = std::make_shared<panel::Transport>(
             lcdDevPath, lcdDevAddr, panel::types::PanelType::LCD);
 
+        // create executor class
+        auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io);
+
+        // create state manager object
+        auto stateManager =
+            std::make_shared<panel::state::manager::PanelStateManager>(
+                lcdPanel, executor);
+
         // create transport base object
         std::shared_ptr<panel::Transport> basePanel;
         if (baseDataMap.find(imValue) != baseDataMap.end())
@@ -100,8 +108,8 @@ int main(int, char**)
         if (panel::utils::lcdDataMap.find(imValue) !=
             panel::utils::lcdDataMap.end())
         {
-            presence = std::make_unique<panel::PanelPresence>(lcdObjPath, conn,
-                                                              lcdPanel);
+            presence = std::make_unique<panel::PanelPresence>(
+                lcdObjPath, conn, lcdPanel, stateManager);
             presence->listenPanelPresence();
 
             /** Race condition can happen when the panel is removed exactly at
@@ -119,14 +127,6 @@ int main(int, char**)
             // set transport key to true for test system(tacoma).
             lcdPanel->setTransportKey(true);
         }
-
-        // create executor class
-        auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io);
-
-        // create state manager object
-        auto stateManager =
-            std::make_shared<panel::state::manager::PanelStateManager>(
-                lcdPanel, executor);
 
         // TODO: via https://github.com/ibm-openbmc/ibm-panel/issues/21
         // Remove this try catch around the button handler once Everest device


### PR DESCRIPTION
After a panel hotplug, lcd panel now displays default
function 01. This gives a visibility to the user that
the panel is up again after a hotplug.

Test:

Tested for both the cases where BMC is NotReady & Ready.

=> When BMC is set to NotReady, and if the lcd panel is present,
we don't get the function 01 display.
Then when BMC is set to Ready, (lcd panel is still present),
function 01 execution takes place (from the BMCState Properties
changed callback).

=> When BMC is Ready and if Panel's present property is changed
from false to true, function 01 is executed.

=======xxx========

busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill xyz.openbmc_project.Inventory.Item  Present b false
busctl set-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill xyz.openbmc_project.Inventory.Item  Present b true

./ibm-panel
Transport key is set to 0 for the panel at /dev/i2c-7, Z

Failed to determine OR fix bootloader bug ...

 Panel:Soft reset done.

 Button configuration done.

Transport key is set to 1 for the panel at /dev/i2c-7, Z

L1 : 01     N    PVM
L2 :             P

Change-Id: I159316f911dfaba3174026fa4689b48111f8c1fa
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>