### PR TITLE
Use code update PEL interface for special case

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -62,5 +62,12 @@ static const types::PanelVersion minPanelVersion('5', '0');
 static const types::PanelVersion maxLCDVersion('5', '2');
 static const types::PanelVersion maxBaseVersion('5', '5');
 static constexpr auto maxFlashWriteChunk = 68;
+
+static constexpr auto deviceReadFailure =
+    "xyz.openbmc_project.Common.Device.Error.ReadFailure";
+static constexpr auto deviceWriteFailure =
+    "xyz.openbmc_project.Common.Device.Error.WriteFailure";
+static constexpr auto codeUpdateFailure =
+    "com.ibm.Panel.Error.CodeUpdateFailure";
 } // namespace constants
 } // namespace panel

--- a/include/transport.hpp
+++ b/include/transport.hpp
@@ -30,9 +30,9 @@ class Transport
      * and device address based on the system type.
      */
     Transport(const std::string& devPath, const uint8_t& devAddr,
-              const types::PanelType& type) :
+              const types::PanelType& type, const std::string& objectPath) :
         devPath(devPath),
-        devAddress(devAddr), panelType(type)
+        devAddress(devAddr), panelType(type), fruPath(objectPath)
     {
         panelI2CSetup();
     }
@@ -107,6 +107,9 @@ class Transport
      * This is required to log CALLOUT_IIC_ADDR in PEL.*/
     std::string i2cAddress{};
 
+    /** @brief Base/LCD panel FRU path */
+    const std::string fruPath;
+
     /** @brief Establish panel i2c connection
      * This api establishes the i2c bus connection to the panel micro
      * controller.
@@ -176,8 +179,10 @@ class Transport
      * @param[in] err - errno.
      * @param[in] control - Says if panel control reaches Main program or Boot
      * loader.
+     * @param[in] pelIntf - PEL interface.
      */
     void logCodeUpdateError(const std::string& description, const int err,
-                            const std::string& control) const;
+                            const std::string& control,
+                            const std::string& pelIntf) const;
 };
 } // namespace panel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -204,8 +204,7 @@ struct PanelVersion
      */
     std::string str() const
     {
-        return std::string{1, static_cast<char>(major)} + "." +
-               std::string{1, static_cast<char>(minor)};
+        return std::string(1, major) + "." + std::string(1, minor);
     }
 };
 

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -81,7 +81,7 @@ int main(int, char**)
 
         // create transport lcd object
         auto lcdPanel = std::make_shared<panel::Transport>(
-            lcdDevPath, lcdDevAddr, panel::types::PanelType::LCD);
+            lcdDevPath, lcdDevAddr, panel::types::PanelType::LCD, lcdObjPath);
 
         // create executor class
         auto executor = std::make_shared<panel::Executor>(lcdPanel, iface, io);
@@ -109,7 +109,8 @@ int main(int, char**)
             basePanel = std::make_shared<panel::Transport>(
                 std::get<0>((baseDataMap.find(imValue))->second),
                 std::get<1>((baseDataMap.find(imValue))->second),
-                panel::types::PanelType::BASE);
+                panel::types::PanelType::BASE,
+                std::get<2>((baseDataMap.find(imValue))->second));
 
             auto& baseObjPath =
                 std::get<2>((baseDataMap.find(imValue))->second);


### PR DESCRIPTION
This commit has changes where the interface "com.ibm.Panel" ".Error.CodeUpdateFailure" will be used only when there is a code update failure due to outdated PIC version.

In cases like panel i2c read and write failures, the interface "xyz.openbmc_project.Common.Device.Error.ReadFailure" and "xyz.openbmc_project.Common.Device.Error.WriteFailure" will be used.

Change-Id: Ic997b97385a9b4be16cc4d1223940c7699557ef3
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>