### PR TITLE
Defect in PIC code update failure handling

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -27,6 +27,8 @@ static constexpr auto rainLcdDbusObj = "/xyz/openbmc_project/inventory/system/"
 static constexpr auto everLcdDbusObj =
     "/xyz/openbmc_project/inventory/system/chassis/motherboard/dasd_backplane/"
     "panel1";
+static constexpr auto everBMCObj =
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard/bmc";
 
 static constexpr auto rain2s2uIM = "50001001";
 static constexpr auto rain2s4uIM = "50001000";
@@ -69,5 +71,12 @@ static constexpr auto deviceWriteFailure =
     "xyz.openbmc_project.Common.Device.Error.WriteFailure";
 static constexpr auto codeUpdateFailure =
     "com.ibm.Panel.Error.CodeUpdateFailure";
+
+// Map of system type to that of path to the FRU on which BootFail PIC is
+// physically present
+static const types::PICFRUPathMap bootFailPIC = {{rain2s2uIM, systemDbusObj},
+                                                 {rain2s4uIM, systemDbusObj},
+                                                 {rain1s4uIM, systemDbusObj},
+                                                 {everestIM, everBMCObj}};
 } // namespace constants
 } // namespace panel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -24,6 +24,7 @@ using PanelDataMap = std::unordered_map<std::string, PanelDataTuple>;
 using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 using PldmPacket = std::vector<uint8_t>;
 using PdrList = std::vector<PldmPacket>;
+using PICFRUPathMap = std::unordered_map<std::string, std::string>;
 
 // map{property::value}
 using PropertyValueMap = std::map<

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -110,7 +110,10 @@ int main(int, char**)
                 std::get<0>((baseDataMap.find(imValue))->second),
                 std::get<1>((baseDataMap.find(imValue))->second),
                 panel::types::PanelType::BASE,
-                std::get<2>((baseDataMap.find(imValue))->second));
+                (panel::constants::bootFailPIC.find(imValue) !=
+                 panel::constants::bootFailPIC.end())
+                    ? panel::constants::bootFailPIC.find(imValue)->second
+                    : std::string());
 
             auto& baseObjPath =
                 std::get<2>((baseDataMap.find(imValue))->second);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -454,11 +454,13 @@ void Transport::logCodeUpdateError(const std::string& description,
     {
         codeUpdatePELData.emplace("MAXIMUM_VERSION",
                                   constants::maxLCDVersion.str());
+        codeUpdatePELData.emplace("CHIP TYPE", "LCD PIC");
     }
     else if (panelType == types::PanelType::BASE)
     {
         codeUpdatePELData.emplace("MAXIMUM_VERSION",
                                   constants::maxBaseVersion.str());
+        codeUpdatePELData.emplace("CHIP TYPE", "BootFail PIC");
     }
 
     codeUpdatePELData.emplace("CONTROL", control);


### PR DESCRIPTION
During the code update failure due to unsupportable version, PEL with interface com.ibm.Panel.Error.CodeUpdateFailure is logged by calling out the INVENTORY_FRU_PATH on which the PIC is physically present.

The Bootfail PIC is physically present on system planar in rainier and on BMC in everest.
The LCD PIC is physically present on LCD panel in rainier and everest.

This commit has changes that calls out right FRU path based on system.

Defect to track SW556967.

Tested on rainier. Code works as expected.

PEL User Data section for LCD PIC update failure:
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_INVENTORY_PATH": "/xyz/openbmc_project/inventory/system/chassis/motherboard/lcd_op_panel_hill",
    "CHIP TYPE": "LCD PIC",
    "CONTROL": "Not reached the Main Program",
    "DESCRIPTION": "FW Code requires minimum version to proceed with code update. Code update fails.",
    "MAXIMUM_VERSION": "5.2",
    "MINIMUM_VERSION": "5.0"
}

PEL User Data section for BootFail PIC update failure: "User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_INVENTORY_PATH": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
    "CHIP TYPE": "BootFail PIC",
    "CONTROL": "In Main Program",
    "DESCRIPTION": "FW Code requires minimum version to proceed with code update. Code update fails.",
    "MAXIMUM_VERSION": "5.5",
    "MINIMUM_VERSION": "5.0"
}

Change-Id: I087ff8b211e4fb63e51d29b5a408d1f2c18c1070
Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>