### PR TITLE
executor: Fix bug in function 20 execution

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -253,7 +253,7 @@ void Executor::execute20()
     if (propData != nullptr)
     {
         line1.replace(0, constants::tmKwdDataLength,
-                      reinterpret_cast<const char*>(propData->data()));
+                      std::string{propData->begin(), propData->end()});
     }
 
     // reading CCIN


### PR DESCRIPTION
Byte array returned as a value for the system MTM was being reinterpreted as a C-string, which was then being used to copy into a display line without any bounds checking.

Fix this by converting the byte array to a std::string first.

Tested:
Execute function 20 a few times in a row. Ensure no corruption on display line 1.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>