### PR TITLE
Handle PEL deletion and update function 64 flow

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -96,13 +96,16 @@ class PELListener
     }
 
     /**
-     * @brief Api to listen for PEL events.
+     * @brief Api to listen for PEL addition/deletion events.
      */
     void listenPelEvents();
 
   private:
     /* Callback to listen for PEL event log */
     void PELEventCallBack(sdbusplus::message::message& msg);
+
+    /* Callback to listen for PEL Delete event log */
+    void PELDeleteEventCallBack(sdbusplus::message::message& msg);
 
     /**
      * @brief An Api to set panel function state based on PEL data.
@@ -136,6 +139,9 @@ class PELListener
 
     /* Check if respective functions are enabled */
     bool functionStateEnabled = false;
+
+    /* Store the last logged PEL with required severity */
+    std::string lastPelObjPath;
 
 }; // class PEL Listener
 

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -62,14 +62,6 @@ class Executor
     }
 
     /**
-     * @brief An api to store event id of last 25 PELs.
-     * This will be required by function 64 sub functions.
-     *
-     * @param[in] pelEventId - Value of eventId property of a given PEL.
-     */
-    void storePelEventId(const std::string& pelEventId);
-
-    /**
      * @brief An api to store latest SRC and Hexwords.
      * This api will receive string consisting SRC and Hexwords and store them
      * to be used in function 11, 12 and 13.
@@ -133,7 +125,26 @@ class Executor
         osIplMode = osIPLModeState;
     }
 
+    /**
+     * @brief An api to store event id of last PEL.
+     * This is required to be dispalyed in function 11 to 13.
+     *
+     * @param pelEventId - Event id data of last PEL.
+     */
+    inline void storeLastPelEventId(const std::string& pelEventId)
+    {
+        latestSrcAndHexwords = pelEventId;
+    }
+
   private:
+    /**
+     * @brief An api to store event id of last 25 PELs.
+     * This will be required by function 64 sub functions.
+     *
+     * @param[in] pelEventId - Value of eventId property of a given PEL.
+     */
+    void storePelEventId(const std::string& pelEventId);
+
     /**
      * @brief An api to execute functionality 20
      */

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -25,6 +25,7 @@ using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 using PldmPacket = std::vector<uint8_t>;
 using PdrList = std::vector<PldmPacket>;
 using PICFRUPathMap = std::unordered_map<std::string, std::string>;
+using PelPathAndSRCList = std::vector<std::pair<std::string, std::string>>;
 
 // map{property::value}
 using PropertyValueMap = std::map<

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <transport.hpp>
 #include <types.hpp>
+#include <vector>
 
 namespace panel
 {
@@ -235,6 +236,33 @@ std::string getSystemIM();
  * @return The value of the presence property.
  */
 bool getLcdPanelPresentProperty(const std::string& imValue);
+
+/**
+ * @brief An API to get list of PELs and SRC logged in the system.
+ *
+ * @return The soreted list of object path and SRCs of last 25 PELs.
+ */
+types::PelPathAndSRCList geListOfPELsAndSRCs();
+
+/**
+ * @brief API to sort list of Pels.
+ * This is required to pick last "n" number of PELs logged in the system.
+ *
+ * @param [in] listOfPels - list of PELs.
+ */
+void sortPels(types::GetManagedObjects& listOfPels);
+
+/**
+ * @brief API to return list of last 25 PELs.
+ * Out of all the PELs retreived from the system, Panel needs to keep track of
+ * PELs only with specific severity. Hence this API will filter those PELs from
+ * the list of all the PELs.
+ *
+ * @param listOfPels - List of PELs retrieved from the system.
+ * @param finalListOFPEls - List of PEL and SRC pair.
+ */
+void filterPel(const types::GetManagedObjects& listOfPels,
+               types::PelPathAndSRCList& finalListOFPEls);
 
 } // namespace utils
 } // namespace panel

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -228,7 +228,6 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                             utils::sendCurrDisplayToPanel(
                                 hexWords.at(4), std::string{}, transport);
                         }
-                        executor->storePelEventId(*eventId);
                         return;
                     }
                     std::cerr << "Event Id length is invalid" << std::endl;
@@ -247,126 +246,6 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
             std::cerr << "Error fetching value of Severity. Ignoring the PEL"
                       << std::endl;
         }
-    }
-}
-
-static void sortPels(types::GetManagedObjects& listOfPels)
-{
-    try
-    {
-        std::sort(listOfPels.begin(), listOfPels.end(),
-                  [](const types::singleObjectEntry& curPelObject,
-                     const types::singleObjectEntry& nextPelObject) {
-                      return (
-                          std::stoi((std::get<0>(curPelObject)).filename()) >
-                          std::stoi((std::get<0>(nextPelObject)).filename()));
-                  });
-    }
-    catch (const std::exception& e)
-    {
-        // stoi (and sort) can throw. Make sure we handle it such that we can
-        // still continue.
-        std::cerr << "Exception: " << e.what() << std::endl;
-        std::cerr << "Failed to sort existing list of PELs" << std::endl;
-    }
-}
-
-void PELListener::filterPel(const types::GetManagedObjects& listOfPels)
-{
-    std::vector<types::singleObjectEntry> finalListOFPEls;
-    finalListOFPEls.reserve(25);
-
-    // Need this as the PEL list is sorted in decreasing order and we need to
-    // store eventIDs in normal order.
-    std::vector<std::string> tempListOfEventId;
-    // need to store 25 event Ids
-    tempListOfEventId.reserve(25);
-
-    for (const auto& aPel : listOfPels)
-    {
-        std::vector<types::InterfacePropertyPair> interfacePropList =
-            std::get<1>(aPel);
-
-        for (const auto& item : interfacePropList)
-        {
-            if (std::get<0>(item) == "xyz.openbmc_project.Logging.Entry")
-            {
-                types::PropertyValueMap propValueMap = std::get<1>(item);
-
-                auto propItr = propValueMap.find("Severity");
-                if (propItr != propValueMap.end())
-                {
-                    const auto severity =
-                        std::get_if<std::string>(&propItr->second);
-
-                    // TODO: Issue 76. Need to check which all severity needs to
-                    // be taken care.
-                    if (severity != nullptr &&
-                        *severity != "xyz.openbmc_project.Logging.Entry."
-                                     "Level.Informational")
-                    {
-                        propItr = propValueMap.find("EventId");
-                        if (propItr != propValueMap.end())
-                        {
-                            if (const auto eventId =
-                                    std::get_if<std::string>(&propItr->second))
-                            {
-                                // this is the PEL we are interested in.
-                                finalListOFPEls.push_back(aPel);
-
-                                // Empty eventId is not possible as length
-                                // of evenId field is hardcoded and is
-                                // guaranteed.
-                                tempListOfEventId.push_back(*eventId);
-
-                                if (tempListOfEventId.size() == 25)
-                                {
-                                    break;
-                                }
-                                continue;
-                            }
-                            std::cerr << "Error fetching value for Event ID. "
-                                         "Not a normal case. Ignoring the PEL"
-                                      << std::endl;
-                            continue;
-                        }
-                        std::cerr << "Mandatory field EventId is missing from "
-                                     "PEL. Ignoring the PEL."
-                                  << std::endl;
-                        continue;
-                    }
-                }
-                else
-                {
-                    std::cerr
-                        << "Mandatory field severity is missing from PEL. "
-                           "Ignoring the PEL"
-                        << std::endl;
-                }
-            }
-        }
-
-        // we need to maintain a list of last 25 pels eventId with a desired
-        // severity.
-        if (tempListOfEventId.size() == 25)
-        {
-            break;
-        }
-    }
-
-    // Implies there are PELs logged in the system with desired severity
-    // before panel came up.
-    if (!finalListOFPEls.empty())
-    {
-        auto it = tempListOfEventId.rbegin();
-        while (it != tempListOfEventId.rend())
-        {
-            executor->storePelEventId(*it);
-            it++;
-        }
-
-        // enable or disable functions based on latest PEL logged.
-        setPelRelatedFunctionState(std::get<0>(finalListOFPEls[0]));
     }
 }
 
@@ -445,23 +324,19 @@ void PELListener::setPelRelatedFunctionState(
 
 void PELListener::getListOfExistingPels()
 {
-    auto listOfPels = utils::getManagedObjects("xyz.openbmc_project.Logging",
-                                               "/xyz/openbmc_project/logging");
+    auto listOfSortedPels = utils::geListOfPELsAndSRCs();
 
-    if (!listOfPels.empty())
+    // Implies there are PELs logged in the system with desired severity
+    // before panel came up.
+    if (!listOfSortedPels.empty())
     {
-        // Remove objects that do not denote PEL entries
-        listOfPels.erase(
-            std::remove_if(
-                listOfPels.begin(), listOfPels.end(),
-                [](const auto& pelObject) {
-                    return !(std::string{std::get<0>(pelObject)}.starts_with(
-                        "/xyz/openbmc_project/logging/entry/"));
-                }),
-            listOfPels.end());
+        // store the last pel details. Required to compare and disable functions
+        // 11 to 19 in case this PEL gets deleted.
+        lastPelObjPath = std::get<0>(listOfSortedPels[0]);
+        executor->storeLastPelEventId(std::get<1>(listOfSortedPels[0]));
 
-        sortPels(listOfPels);
-        filterPel(listOfPels);
+        // enable or disable functions based on latest PEL logged.
+        setPelRelatedFunctionState(lastPelObjPath);
     }
 }
 
@@ -473,7 +348,38 @@ void PELListener::listenPelEvents()
             "/xyz/openbmc_project/logging"),
         [this](sdbusplus::message::message& msg) { PELEventCallBack(msg); });
 
+    static auto infRemovedSigMatch =
+        std::make_unique<sdbusplus::bus::match::match>(
+            *conn,
+            sdbusplus::bus::match::rules::interfacesRemoved(
+                "/xyz/openbmc_project/logging"),
+            [this](sdbusplus::message::message& msg) {
+                PELDeleteEventCallBack(msg);
+            });
+
     getListOfExistingPels();
+}
+
+void PELListener::PELDeleteEventCallBack(sdbusplus::message::message& msg)
+{
+    sdbusplus::message::object_path objPath;
+    std::vector<std::string> interface;
+    msg.read(objPath, interface);
+
+    for (const auto& element : interface)
+    {
+        if (element == "xyz.openbmc_project.Object.Delete")
+        {
+            if (objPath == lastPelObjPath)
+            {
+                // We need to disable function 11 to 19 as the last PEL of
+                // required severity has been deleted.
+                stateManager->disableFunctonality(
+                    {11, 12, 13, 14, 15, 16, 18, 18, 19});
+                lastPelObjPath.clear();
+            }
+        }
+    }
 }
 
 void BootProgressCode::listenProgressCode()

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -832,6 +832,20 @@ void Executor::storePelEventId(const std::string& pelEventId)
 
 void Executor::execute64(const types::FunctionNumber subFuncNumber)
 {
+    auto listOfPels = utils::geListOfPELsAndSRCs();
+
+    if (!listOfPels.empty())
+    {
+        // done in reverse order as the PELs are sorted in descending order and
+        // we want this queue in ascending order.
+        auto it = listOfPels.rbegin();
+        while (it != listOfPels.rend())
+        {
+            storePelEventId(std::get<1>(*it));
+            it++;
+        }
+    }
+
     // 0th Sub function is always enabled and should show blank screen if
     // required.
     if ((subFuncNumber == 0) && (pelEventIdQueue.size() == 0))


### PR DESCRIPTION
The commit implement changes to handle PEL deletion event, where in case last stored PEL was deleted then function 11 to 19 will be set to disabled mode.

It also make changes to the flow of function 64, where only after execution of function 64 the code will fetch and filter the list of diagnostic SRCs required to be displayed via this function.

Test Pending...

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>