### PR TITLE
Fix enabling of function 14 to 19

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -400,6 +400,8 @@ void PELListener::setPelRelatedFunctionState(
 
             // Need to show max 6 callout src.
             auto size = std::min(callOutList.size(), static_cast<size_t>(6));
+            // if resolution is not there size should not be set to negative.
+            size = (size == 0) ? static_cast<size_t>(0) : (size - 1);
 
             // default list: 14 to 19 are the functions to display
             // callout SRCs.


### PR DESCRIPTION
As the count of call out was not adjusted w.r.t 0th index being the first entry, there was an extra function getting enabled in the call out SRC function list.

The commit fixes that issue.

Test:
- Restart the panel service.
- Refer to the latest PEL resolution data from GUI.
- Check on LDC panel, number of functons enabled between 14 to 19 should be equal to the count of resolution string for the latest PEL with desired severity.

Change-Id: Ic66cfcbd5fcf62cef87a7c642cea01e3e4736ec5
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>