### PR TITLE
Handle PEL deletion and update function 64 flow

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -86,13 +86,16 @@ class PELListener
     }
 
     /**
-     * @brief Api to listen for PEL events.
+     * @brief Api to listen for PEL addition/deletion events.
      */
     void listenPelEvents();
 
   private:
     /* Callback to listen for PEL event log */
     void PELEventCallBack(sdbusplus::message::message& msg);
+
+    /* Callback to listen for PEL Delete event log */
+    void PELDeleteEventCallBack(sdbusplus::message::message& msg);
 
     /**
      * @brief An Api to set panel function state based on PEL data.
@@ -126,6 +129,9 @@ class PELListener
 
     /* Check if respective functions are enabled */
     bool functionStateEnabled = false;
+
+    /* Store the last logged PEL with required severity */
+    std::string lastPelObjPath;
 
 }; // class PEL Listener
 

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -62,14 +62,6 @@ class Executor
     }
 
     /**
-     * @brief An api to store event id of last 25 PELs.
-     * This will be required by function 64 sub functions.
-     *
-     * @param[in] pelEventId - Value of eventId property of a given PEL.
-     */
-    void storePelEventId(const std::string& pelEventId);
-
-    /**
      * @brief An api to store latest SRC and Hexwords.
      * This api will receive string consisting SRC and Hexwords and store them
      * to be used in function 11, 12 and 13.
@@ -82,15 +74,12 @@ class Executor
     }
 
     /**
-     * @brief An api to return count of Pel EventIds.
+     * @brief An api to fetch PELs return count of Pel EventIds.
      * This count is required to enable/disable sub functions by state manager
      * w.r.t function 64.
      * @return The current count of stored PEL SRCs.
      */
-    inline uint8_t getPelEventIdCount() const
-    {
-        return pelEventIdQueue.size();
-    }
+    uint8_t getPelEventIdCount();
 
     /**
      * @brief An api to store last 25 IPL SRCs.
@@ -133,7 +122,26 @@ class Executor
         osIplMode = osIPLModeState;
     }
 
+    /**
+     * @brief An api to store event id of last PEL.
+     * This is required to be dispalyed in function 11 to 13.
+     *
+     * @param pelEventId - Event id data of last PEL.
+     */
+    inline void storeLastPelEventId(const std::string& pelEventId)
+    {
+        latestSrcAndHexwords = pelEventId;
+    }
+
   private:
+    /**
+     * @brief An api to store event id of last 25 PELs.
+     * This will be required by function 64 sub functions.
+     *
+     * @param[in] pelEventId - Value of eventId property of a given PEL.
+     */
+    void storePelEventId(const std::string& pelEventId);
+
     /**
      * @brief An api to execute functionality 20
      */

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -39,6 +39,13 @@ class PanelStateManager
     }
 
     /**
+     * @brief Api to reset state manager.
+     * This needs to be called when we want to reset the state manager and LCD
+     * panel to function 01.
+     */
+    void resetStateManager();
+
+    /**
      * @brief Api to get state and sub state info of panel.
      * */
     std::tuple<types::FunctionNumber, types::FunctionNumber>

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -24,6 +24,8 @@ using PanelDataMap = std::unordered_map<std::string, PanelDataTuple>;
 using ItemInterfaceMap = std::map<std::string, std::variant<bool, std::string>>;
 using PldmPacket = std::vector<uint8_t>;
 using PdrList = std::vector<PldmPacket>;
+using PICFRUPathMap = std::unordered_map<std::string, std::string>;
+using PelPathAndSRCList = std::vector<std::pair<std::string, std::string>>;
 
 // map{property::value}
 using PropertyValueMap = std::map<

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <transport.hpp>
 #include <types.hpp>
+#include <vector>
 
 namespace panel
 {
@@ -202,6 +203,33 @@ void getSensorDataFromPdr(const types::PdrList& stateSensorPdr,
 std::vector<std::string> getSubTreePaths(const std::string& objectPath,
                                          const std::vector<std::string>& intf,
                                          const int32_t depth);
+
+/**
+ * @brief An API to get list of PELs and SRC logged in the system.
+ *
+ * @return The sorted list of object path and SRCs of last 25 PELs.
+ */
+types::PelPathAndSRCList geListOfPELsAndSRCs();
+
+/**
+ * @brief API to sort list of Pels.
+ * This is required to pick last "n" number of PELs logged in the system.
+ *
+ * @param [in] listOfPels - list of PELs.
+ */
+void sortPels(types::GetManagedObjects& listOfPels);
+
+/**
+ * @brief API to return list of last 25 PELs.
+ * Out of all the PELs retreived from the system, Panel needs to keep track of
+ * PELs only with specific severity. Hence this API will filter those PELs from
+ * the list of all the PELs.
+ *
+ * @param listOfPels - List of PELs retrieved from the system.
+ * @param finalListOFPEls - List of PEL and SRC pair.
+ */
+void filterPel(const types::GetManagedObjects& listOfPels,
+               types::PelPathAndSRCList& finalListOFPELs);
 
 } // namespace utils
 } // namespace panel

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -830,6 +830,25 @@ void Executor::storePelEventId(const std::string& pelEventId)
     latestSrcAndHexwords = pelEventId;
 }
 
+uint8_t Executor::getPelEventIdCount()
+{
+    auto listOfPels = utils::geListOfPELsAndSRCs();
+
+    if (!listOfPels.empty())
+    {
+        // done in reverse order as the PELs are sorted in descending order and
+        // we want this queue in ascending order.
+        auto it = listOfPels.rbegin();
+        while (it != listOfPels.rend())
+        {
+            storePelEventId(std::get<1>(*it));
+            it++;
+        }
+    }
+
+    return pelEventIdQueue.size();
+}
+
 void Executor::execute64(const types::FunctionNumber subFuncNumber)
 {
     // 0th Sub function is always enabled and should show blank screen if

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -339,6 +339,15 @@ void PanelStateManager::processPanelButtonEvent(
     // printPanelStates();
 }
 
+void PanelStateManager::resetStateManager()
+{
+    panelCurState = StateType::INITIAL_STATE;
+    panelCurSubStates.push_back(StateType::INITIAL_STATE);
+    panelCurSubStates.push_back(StateType::INVALID_STATE);
+    panelCurSubStates.push_back(StateType::INVALID_STATE);
+    funcExecutor->executeFunction(01, types::FunctionalityList{});
+}
+
 void PanelStateManager::initPanelState()
 {
     for (const auto& singleFunctionality : functionalityList)
@@ -751,6 +760,8 @@ void PanelStateManager::executeState()
                 // number of Pel event received so far.
                 if (funcState.functionNumber == FUNCTION_64)
                 {
+                    // fetch the existing list of PELs in the system, filter
+                    // them and store their event Id for sub functions.
                     count = funcExecutor->getPelEventIdCount();
                 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,5 +319,125 @@ std::vector<std::string> getSubTreePaths(const std::string& objectPath,
     return result;
 }
 
+void filterPel(const types::GetManagedObjects& listOfPels,
+               types::PelPathAndSRCList& finalListOFPELs)
+{
+    finalListOFPELs.reserve(25);
+
+    for (const auto& aPel : listOfPels)
+    {
+        std::vector<types::InterfacePropertyPair> interfacePropList =
+            std::get<1>(aPel);
+
+        for (const auto& item : interfacePropList)
+        {
+            if (std::get<0>(item) == "xyz.openbmc_project.Logging.Entry")
+            {
+                types::PropertyValueMap propValueMap = std::get<1>(item);
+
+                auto propItr = propValueMap.find("Severity");
+                if (propItr != propValueMap.end())
+                {
+                    const auto severity =
+                        std::get_if<std::string>(&propItr->second);
+
+                    // TODO: Issue 76. Need to check which all severity needs to
+                    // be taken care.
+                    if (severity != nullptr &&
+                        *severity != "xyz.openbmc_project.Logging.Entry."
+                                     "Level.Informational")
+                    {
+                        propItr = propValueMap.find("EventId");
+                        if (propItr != propValueMap.end())
+                        {
+                            if (const auto eventId =
+                                    std::get_if<std::string>(&propItr->second))
+                            {
+                                // this is the PEL we are interested in.
+                                finalListOFPELs.push_back(std::make_pair(
+                                    std::get<0>(aPel), *eventId));
+
+                                if (finalListOFPELs.size() == 25)
+                                {
+                                    break;
+                                }
+                                continue;
+                            }
+                            std::cerr << "Error fetching value for Event ID. "
+                                         "Not a normal case. Ignoring the PEL"
+                                      << std::endl;
+                            continue;
+                        }
+                        std::cerr << "Mandatory field EventId is missing from "
+                                     "PEL. Ignoring the PEL."
+                                  << std::endl;
+                        continue;
+                    }
+                }
+                else
+                {
+                    std::cerr
+                        << "Mandatory field severity is missing from PEL. "
+                           "Ignoring the PEL"
+                        << std::endl;
+                }
+            }
+        }
+
+        // we need to maintain a list of last 25 pels eventId with a desired
+        // severity.
+        if (finalListOFPELs.size() == 25)
+        {
+            break;
+        }
+    }
+}
+
+void sortPels(types::GetManagedObjects& listOfPels)
+{
+    try
+    {
+        std::sort(listOfPels.begin(), listOfPels.end(),
+                  [](const types::singleObjectEntry& curPelObject,
+                     const types::singleObjectEntry& nextPelObject) {
+                      return (
+                          std::stoi((std::get<0>(curPelObject)).filename()) >
+                          std::stoi((std::get<0>(nextPelObject)).filename()));
+                  });
+    }
+    catch (const std::exception& e)
+    {
+        // stoi (and sort) can throw. Make sure we handle it such that we can
+        // still continue.
+        std::cerr << "Exception: " << e.what() << std::endl;
+        std::cerr << "Failed to sort existing list of PELs" << std::endl;
+    }
+}
+
+types::PelPathAndSRCList geListOfPELsAndSRCs()
+{
+    auto listOfPels = getManagedObjects("xyz.openbmc_project.Logging",
+                                        "/xyz/openbmc_project/logging");
+
+    types::PelPathAndSRCList finalListOfFPELs{};
+    if (!listOfPels.empty())
+    {
+        // Remove objects that do not denote PEL entries
+        listOfPels.erase(
+            std::remove_if(
+                listOfPels.begin(), listOfPels.end(),
+                [](const auto& pelObject) {
+                    return !(std::string{std::get<0>(pelObject)}.starts_with(
+                        "/xyz/openbmc_project/logging/entry/"));
+                }),
+            listOfPels.end());
+
+        sortPels(listOfPels);
+        filterPel(listOfPels, finalListOfFPELs);
+    }
+
+    return finalListOfFPELs;
+}
+
 } // namespace utils
 } // namespace panel


### PR DESCRIPTION
The commit implement changes to handle PEL deletion event, where in case last stored PEL was deleted then function 11 to 19 will be set to disabled mode.

It also make changes to the flow of function 64, where only after execution of function 64 the code will fetch and filter the list of diagnostic SRCs required to be displayed via this function.

Change-Id: I88a55a2fd5f8220672eef0b9477fa688c48a4aa3
Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>