### PR TITLE
Add error log for read failures

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -72,6 +72,9 @@ static constexpr auto deviceWriteFailure =
 static constexpr auto codeUpdateFailure =
     "com.ibm.Panel.Error.CodeUpdateFailure";
 
+// Errno defines
+static constexpr auto errnoNoDeviceOrAddress = 6;
+
 // Map of system type to that of path to the FRU on which BootFail PIC is
 // physically present
 static const types::PICFRUPathMap bootFailPIC = {{rain2s2uIM, systemDbusObj},


### PR DESCRIPTION
Adding error klog when reading the version fails , so that we can determine if the hardware has a problem or the firmware has an issue.

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>