### PR TITLE
Add error log for read failures

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -72,6 +72,9 @@ static constexpr auto deviceWriteFailure =
 static constexpr auto codeUpdateFailure =
     "com.ibm.Panel.Error.CodeUpdateFailure";
 
+// Errno defines
+static constexpr auto errnoNoDeviceOrAddress = 6;
+
 // Map of system type to that of path to the FRU on which BootFail PIC is
 // physically present
 static const types::PICFRUPathMap bootFailPIC = {{rain2s2uIM, systemDbusObj},

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -215,8 +215,19 @@ bool Transport::readPanelVersion(types::Binary& versionBuffer) const
     {
         std::cerr << "Failed to read panel current version [" << devPath << ", "
                   << i2cAddress << "]. Bytes read: " << readSize
-                  << ", errno: " << errno
-                  << "error statement = " << std::to_string(errno) << std::endl;
+                  << ", errno: " << errno << std::endl;
+        if (constants::errnoNoDeviceOrAddress == errno)
+        {
+	    // creating errorlog as device not found, it could be due to
+	    // hardware issue or it could be due to blank firmware.
+	    std::map<std::string, std::string> errorInfo{};
+	    errorInfo.emplace("CALLOUT_IIC_BUS", devPath);
+	    errorInfo.emplace("CALLOUT_IIC_ADDR", i2cAddress);
+	    errorInfo.emplace("CALLOUT_ERRNO", std::to_string(err));
+	    utils::createPEL(constants::deviceReadFailure,
+			     "xyz.openbmc_project.Logging.Entry.Level.Error",
+			     errorInfo);
+	}
         return false;
     }
     return true;


### PR DESCRIPTION
Adding error klog when reading the version fails , so that we can determine if the hardware has a problem or the firmware has an issue.

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>