### PR TITLE
Add error log for read failures

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -223,7 +223,7 @@ bool Transport::readPanelVersion(types::Binary& versionBuffer) const
             std::map<std::string, std::string> errorInfo{};
             errorInfo.emplace("CALLOUT_IIC_BUS", devPath);
             errorInfo.emplace("CALLOUT_IIC_ADDR", i2cAddress);
-            errorInfo.emplace("CALLOUT_ERRNO", std::to_string(err));
+            errorInfo.emplace("CALLOUT_ERRNO", std::to_string(errno));
             utils::createPEL(constants::deviceReadFailure,
                              "xyz.openbmc_project.Logging.Entry.Level.Error",
                              errorInfo);


### PR DESCRIPTION
Adding error klog when reading the version fails , so that we can determine if the hardware has a problem or the firmware has an issue.

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>