### PR TITLE
Update function state and data on PEL deletion

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -111,6 +111,8 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                             utils::sendCurrDisplayToPanel(
                                 hexWords.at(4), std::string{}, transport);
                         }
+                        executor->storeLastPelEventId(*eventId);
+                        lastPelObjPath = objPath;
                         return;
                     }
                     std::cerr << "Event Id length is invalid" << std::endl;
@@ -260,6 +262,9 @@ void PELListener::PELDeleteEventCallBack(sdbusplus::message::message& msg)
                 stateManager->disableFunctonality(
                     {11, 12, 13, 14, 15, 16, 17, 18, 19});
                 lastPelObjPath.clear();
+
+                // as functions are disabled, set the flag to false
+                functionStateEnabled = false;
 
                 // reset LCD panel to display function 01 as there can be a
                 // situation where user is already on one of the function


### PR DESCRIPTION
The commit fixes issue where function 11 to 13 were not getting enabled after a cycle where a PEL was logged then deleted and then logged.

It also fixes the issue where function 11 was holding old SRC data once the above cycle was performed.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>