### PR TITLE
Update function state and data on PEL deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # IBM Panel Application
+
 The IBM Panel application is a daemon that interacts with and handles button
 presses from the IBM Operator Panel hardware.
 
 Mainly, this application provides the following functions:
+
 - Display text/information on the panel.
 - Handle button presses coming from the panel.
 - Invoke actions on the BMC based on those button presses.

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -226,6 +226,8 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                             utils::sendCurrDisplayToPanel(
                                 hexWords.at(4), std::string{}, transport);
                         }
+                        executor->storeLastPelEventId(*eventId);
+                        lastPelObjPath = objPath;
                         return;
                     }
                     std::cerr << "Event Id length is invalid" << std::endl;
@@ -377,6 +379,9 @@ void PELListener::PELDeleteEventCallBack(sdbusplus::message::message& msg)
                 stateManager->disableFunctonality(
                     {11, 12, 13, 14, 15, 16, 17, 18, 19});
                 lastPelObjPath.clear();
+
+                // as functions are disabled, set the flag to false
+                functionStateEnabled = false;
 
                 // reset LCD panel to display function 01 as there can be a
                 // situation where user is already on one of the function

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -218,16 +218,16 @@ bool Transport::readPanelVersion(types::Binary& versionBuffer) const
                   << ", errno: " << errno << std::endl;
         if (constants::errnoNoDeviceOrAddress == errno)
         {
-	    // creating errorlog as device not found, it could be due to
-	    // hardware issue or it could be due to blank firmware.
-	    std::map<std::string, std::string> errorInfo{};
-	    errorInfo.emplace("CALLOUT_IIC_BUS", devPath);
-	    errorInfo.emplace("CALLOUT_IIC_ADDR", i2cAddress);
-	    errorInfo.emplace("CALLOUT_ERRNO", std::to_string(errno));
-	    utils::createPEL(constants::deviceReadFailure,
-			     "xyz.openbmc_project.Logging.Entry.Level.Error",
-			     errorInfo);
-	}
+            // creating errorlog as device not found, it could be due to
+            // hardware issue or it could be due to blank firmware.
+            std::map<std::string, std::string> errorInfo{};
+            errorInfo.emplace("CALLOUT_IIC_BUS", devPath);
+            errorInfo.emplace("CALLOUT_IIC_ADDR", i2cAddress);
+            errorInfo.emplace("CALLOUT_ERRNO", std::to_string(errno));
+            utils::createPEL(constants::deviceReadFailure,
+                             "xyz.openbmc_project.Logging.Entry.Level.Error",
+                             errorInfo);
+        }
         return false;
     }
     return true;


### PR DESCRIPTION
The commit fixes issue where function 11 to 13 were not getting enabled after a cycle where a PEL was logged then deleted and then logged.

It also fixes the issue where function 11 was holding old SRC data once the above cycle was performed.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>