### PR TITLE
panel: Function 30 unable to fetch network objects

### DIFF
--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -386,11 +386,10 @@ void Executor::execute30(const types::FunctionalityList& subFuncNumber)
     {
         const std::string& objPath =
             std::get<sdbusplus::message::object_path>(obj);
-        // search for eth0/eth1 ipv4 objects based on input
-        // eg: /xyz/openbmc_project/network/eth0/ipv4/bb39e832
-        std::string ethV4 = "/";
-        ethV4 += ethPort;
-        ethV4 += "/ipv4/";
+
+        // search for eth0/eth1 objects
+        std::string ethV4 = "/" + ethPort + "/";
+
         const auto& intfPropVector = std::get<1>(obj);
         if (objPath.find(ethV4) != std::string::npos)
         {


### PR DESCRIPTION
Network manager object path pattern has been changed recently, due to which function 30 in panel breaks. This commit has a fix to use the new pattern.

Test:
Tested on rainier.
Able to fetch both eth0 and eth1 ip address and location code using function 30.

Change-Id: I2b58144f4e6d59258b056567ac48be8f399ddfa7