### PR TITLE
Display SRC word 0 for terminating SRCs and consider a checkstop a terminating SRC

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -53,7 +53,7 @@ static constexpr auto locCodeIntf =
 static constexpr auto tmKwdDataLength = 8;
 static constexpr auto ccinDataLength = 4;
 static constexpr auto fiveHexWordsWithSpaces = 44;
-static constexpr auto terminatingBit = 2;
+static constexpr auto terminatingBits = 0xA; // Checkstop and Term due to FW
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -224,7 +224,7 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                             // code is for BMC i.e "BD". Send it
                             // directly to display.
                             utils::sendCurrDisplayToPanel(
-                                hexWords.at(4), std::string{}, transport);
+                                hexWords.at(0), std::string{}, transport);
                         }
                         executor->storeLastPelEventId(*eventId);
                         lastPelObjPath = objPath;

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -217,7 +217,7 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                         types::Byte byte =
                             ::strtoul(valueAtIndexZero, nullptr, 16);
 
-                        if ((byte & constants::terminatingBit) != 0x00 &&
+                        if ((byte & constants::terminatingBits) != 0x00 &&
                             (hexWords[0][0] == 'B' && hexWords[0][1] == 'D'))
                         {
                             // if terminating bit is set and response


### PR DESCRIPTION
Bit 0 in hex word 5 of BMC SRCs indicates the PEL is for a checkstop, which should be posted on the panel so that the op panel isn't just left with whatever was posted previous to the hostboot/OS crash.

Also, display word 0 of the SRC event ID field, which is the ascii string field of the SRC, like the BD50E510.