### PR TITLE
Add logging dependency to service file

### DIFF
--- a/service_files/ibm.panel.system.vpd.dependent.service
+++ b/service_files/ibm.panel.system.vpd.dependent.service
@@ -3,6 +3,8 @@ Description=IBM operator panel application.
 StopWhenUnneeded=false
 Requires=system-vpd.service
 After=system-vpd.service
+Wants=xyz.openbmc_project.Logging.service
+After=xyz.openbmc_project.Logging.service
 
 [Service]
 BusName=com.ibm.PanelApp


### PR DESCRIPTION
When there are a lot of error logs on a system, like over 1000, and the panel app tries to create a PEL when it starts up, it may fail because the log-manager daemon is still restoring event logs onto D-Bus and hasn't claimed a bus name yet.

It will exit and then restart itself and try again, and that may keep happening until the limit is reached and the BMC goes into Quiesce state.

To fix this, put a dependency in the service file on the logging service.  As far as I know there is nothing displayed on the panel on startup so it wouldn't matter if the panel daemon is delayed a bit.

Since it's just a 'Wants' dependency if the logging daemon fails to start the panel app can still start.

The failing traces look like:

```
systemd[1]: Starting IBM operator panel application....
ibm-panel[1180]: Success opening and accessing the device path: /dev/i2c-7
ibm-panel[1180]: Success opening and accessing the device path: /dev/i2c-3
ibm-panel[1180]: Validated that the panel is running the main program
ibm-panel[1180]:  The current version of Op-panel at /dev/i2c-3, 0x5A is 4.0
ibm-panel[1180]: Service name is not foundPanel app exiting...
systemd[1]: com.ibm.panel.service: Deactivated successfully.
systemd[1]: Started IBM operator panel application..
systemd[1]: com.ibm.panel.service: Scheduled restart job, restart counter is at 1.
systemd[1]: Stopped IBM operator panel application..
systemd[1]: Starting IBM operator panel application....
systemd[1]: Started IBM operator panel application..
ibm-panel[1440]: Success opening and accessing the device path: /dev/i2c-7
ibm-panel[1440]: Success opening and accessing the device path: /dev/i2c-3
ibm-panel[1440]: Validated that the panel is running the main program
ibm-panel[1440]:  The current version of Op-panel at /dev/i2c-3, 0x5A is 4.0
ibm-panel[1440]: Service name is not foundPanel app exiting...
systemd[1]: com.ibm.panel.service: Deactivated successfully.
systemd[1]: com.ibm.panel.service: Scheduled restart job, restart counter is at 2.
systemd[1]: Stopped IBM operator panel application..
systemd[1]: com.ibm.panel.service: Start request repeated too quickly.
systemd[1]: com.ibm.panel.service: Failed with result 'start-limit-hit'.
systemd[1]: Failed to start IBM operator panel application..
```