### PR TITLE
Disable of OS IPL mode in function-02

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -123,6 +123,22 @@ class Executor
     }
 
     /**
+     * @brief API to get value of panel DBus property osIplMode.
+     *
+     * This api is called to fetch the current value of osIplMode property which
+     * is exposed under panel interface. Value of this property tells wether
+     * OS IPL Mode fetched from the BIOS attribute should be displayed in
+     * function 01 and function 02.
+     *
+     * @param[in] osIPLModeState - current osIPLMode
+     * @return Value of the property as set in case of setOSIPLMode API.
+     */
+    inline bool isOSIPLModeEnabled() const
+    {
+        return osIplMode;
+    }
+
+    /**
      * @brief An api to store event id of last PEL.
      * This is required to be dispalyed in function 11 to 13.
      *

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -183,7 +183,7 @@ class PanelStateManager
     void displayDebounce() const;
 
     /** @brief Api to display function 2 on panel */
-    void displayFunc02() const;
+    void displayFunc02();
 
     /**
      * @brief An api to initialise function 02 with its initial values.

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -864,7 +864,7 @@ void PanelStateManager::displayDebounce() const
 0 2 _ _ B_ _N __ __ _ _ _ _
 _ _ _ _ __ __ __ __ T < _ _
 */
-void PanelStateManager::displayFunc02() const
+void PanelStateManager::displayFunc02()
 {
     std::string line1(16, ' ');
     std::string line2(16, ' ');
@@ -873,7 +873,23 @@ void PanelStateManager::displayFunc02() const
 
     if (isSubrangeActive)
     {
-        line1.replace(4, 1, functionality02.at(0).at(panelCurSubStates.at(0)));
+        // If this property is set as false under panel interface,
+        // implies that panel should not display OS IPL mode via function-02.
+        if (funcExecutor->isOSIPLModeEnabled())
+        {
+            line1.replace(4, 1,
+                          functionality02.at(0).at(panelCurSubStates.at(0)));
+        }
+        else
+        {
+            // Move the cursor to second level in case OS IPL mode is not
+            // displayed.
+            if (levelToOperate == 0)
+            {
+                levelToOperate++;
+            }
+        }
+
         line1.replace(7, 1, functionality02.at(1).at(panelCurSubStates.at(1)));
         line2.replace(12, 1, functionality02.at(2).at(panelCurSubStates.at(2)));
 


### PR DESCRIPTION
The commit omits display and editing of OS IPL mode via function-02 unless the property osIplMode is set as true in panel interface via PLDM.

The property is set when the system has single partition with HMC connected.

Test:
- Boot a system with the property osIplMode under panel interface set as false.
- Launch function-02 on operator panel.
- Initial screen will not display OS IPL mode.

Implies in this mode user will not be allowed to edit OS IPL mode via panel.