### PR TITLE
Set operating mode based on BIOS table

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -237,10 +237,10 @@ class SystemStatus
     void listenBootProgressState();
 
     /**
-     * @brief Listen for system operating mode parameters.
+     * @brief Listen for system operating mode in BIOS attributes.
      * An api to register call back for system operating mode change.
      */
-    void listenSystemOperatingModeParameters();
+    void listenSystemOperatingMode();
 
     /**
      * @brief Api to handle BMC state change callback.
@@ -273,19 +273,21 @@ class SystemStatus
     void rebootPolicyStateCallback(sdbusplus::message::message& msg);
 
     /**
-     * @brief Api to initialize system operating parameters.
+     * @brief Api to initialize system operating mode.
+     *
+     * The API sets the state manager's system state based on the operating mode
+     * at the time of panel coming up.
      */
-    void initSystemOperatingParameters();
+    void initSystemOperatingMode();
 
     /**
-     * @brief Set system operating mode.
-     * An api to set system operating mode based on the value of three
-     * parameters required to detect operating mode.
-     * a) Logging Setting.
-     * b) Power policy.
-     * c) Reboot policy.
+     * @brief BIOS attribute change callback.
+     *
+     * Listens to system operating mode property change in BIOS base table.
+     *
+     * @param[in] msg - Callback message.
      */
-    void setSystemCurrentOperatingMode();
+    void biosAttributesCallback(sdbusplus::message::message& msg);
 
     /* D-Bus connection. */
     std::shared_ptr<sdbusplus::asio::connection> conn;

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -40,19 +40,20 @@ map{InterfaceName, map{propertyName, value}}
 */
 using DbusInterfaceMap = std::map<std::string, PropertyValueMap>;
 
+using BiosProperty = std::tuple<
+    std::string, bool, std::string, std::string, std::string,
+    std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
+    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>>>>;
 /*baseBIOSTable reference
 map{attributeName,struct{attributeType,readonlyStatus,displayname,
               description,menuPath,current,default,
               array{struct{optionstring,optionvalue}}}}
 */
-using BiosBaseTableItem = std::pair<
-    std::string,
-    std::tuple<
-        std::string, bool, std::string, std::string, std::string,
-        std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
-        std::vector<
-            std::tuple<std::string, std::variant<int64_t, std::string>>>>>;
+using BiosBaseTableItem = std::pair<std::string, BiosProperty>;
 using BiosBaseTable = std::vector<BiosBaseTableItem>;
+
+using BiosBaseTableType =
+    std::map<std::string, std::variant<std::map<std::string, BiosProperty>>>;
 
 /* SystemParameterValues reference
  std::tuple<os_ipl_type, system_operating_mode, hmc_managed, fw_boot_side,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -96,24 +96,6 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
                             std::shared_ptr<Transport> transport);
 
 /**
- * @brief An api to read System operating mode.
- * It will use combination of below mentioned three parameters to
- * decide the operating mode of the system.
- *
- * By default it will be "Normal " mode.
- * Value of three parameters in "Manual" mode would be,
- * QuiesceOnHwError - true.
- * PowerRestorePolicy -
- * "xyz.openbmc_project.Control.Power.RestorePolicy.Policy.AlwaysOff".
- * AutoReboot - false.
- *
- * Any other value combination will set the system to "Normal" mode.
- *
- * @param[out] sysOperatingMode - Operating mode.
- */
-void readSystemOperatingMode(std::string& sysOperatingMode);
-
-/**
  * @brief An api to read initial values of OS IPL types, System operating
  * mode, firmware IPL type, Hypervisor type and HMC indicator.
  * @return - Values of required system parameters.

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -512,11 +512,11 @@ SystemStatus::SystemStatus(
     conn(con),
     stateManager(manager)
 {
-    initSystemOperatingParameters();
+    initSystemOperatingMode();
     listenBmcState();
     listenBootProgressState();
     listenPowerState();
-    listenSystemOperatingModeParameters();
+    listenSystemOperatingMode();
 }
 
 void SystemStatus::bmcStateCallback(sdbusplus::message::message& msg)
@@ -665,129 +665,69 @@ void SystemStatus::listenBootProgressState()
         });
 }
 
-void SystemStatus::powerPolicyStateCallback(sdbusplus::message::message& msg)
+void SystemStatus::biosAttributesCallback(sdbusplus::message::message& msg)
 {
-    std::string object{};
-    types::ItemInterfaceMap invItemMap;
-
-    msg.read(object, invItemMap);
-    const auto itr = invItemMap.find("PowerRestorePolicy");
-    if (itr != invItemMap.end())
+    if (msg.is_method_error())
     {
-        if (auto powerState = std::get_if<std::string>(&(itr->second)))
-        {
-            // std::cout << "power state = " << *powerState << std::endl;
-            powerPolicy = *powerState;
+        std::cerr << "Error in reading BIOS attribute signal " << std::endl;
+        return;
+    }
 
-            setSystemCurrentOperatingMode();
-        }
-        else
+    std::string object;
+    types::BiosBaseTableType propMap;
+    msg.read(object, propMap);
+    for (auto property : propMap)
+    {
+        if (property.first == "BaseBIOSTable")
         {
-            std::cerr << "Failed to read power policy from Dbus" << std::endl;
+            auto biosBaseTable = std::get<0>(property.second);
+            for (const auto& biosItem : biosBaseTable)
+            {
+                auto attributeName = std::get<0>(biosItem);
+                if (attributeName == "pvm_system_operating_mode")
+                {
+                    auto attrValue = std::get<5>(std::get<1>(biosItem));
+                    if (auto val = std::get_if<std::string>(&attrValue))
+                    {
+                        stateManager->setSystemOperatingMode(*val);
+                    }
+                    else
+                    {
+                        std::cerr << "Error reading bios attribute for system "
+                                     "operating mode"
+                                  << std::endl;
+                    }
+                }
+            }
         }
     }
 }
 
-void SystemStatus::rebootPolicyStateCallback(sdbusplus::message::message& msg)
+void SystemStatus::listenSystemOperatingMode()
 {
-    std::string object{};
-    types::ItemInterfaceMap invItemMap;
-
-    msg.read(object, invItemMap);
-    const auto itr = invItemMap.find("AutoReboot");
-    if (itr != invItemMap.end())
-    {
-        if (auto rebootState = std::get_if<bool>(&(itr->second)))
-        {
-            // std::cout << "reboot state = " << *rebootState << std::endl;
-            rebootPolicy = *rebootState;
-
-            setSystemCurrentOperatingMode();
-        }
-        else
-        {
-            std::cerr << "Failed to read reboot policy from Dbus" << std::endl;
-        }
-    }
-}
-
-void SystemStatus::listenSystemOperatingModeParameters()
-{
-    static auto sigPowerPolicy = std::make_unique<sdbusplus::bus::match::match>(
+    static auto biosMatcher = std::make_unique<sdbusplus::bus::match::match>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
-            "/xyz/openbmc_project/control/host0/power_restore_policy",
-            "xyz.openbmc_project.Control.Power.RestorePolicy"),
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager"),
         [this](sdbusplus::message::message& msg) {
-            powerPolicyStateCallback(msg);
+            biosAttributesCallback(msg);
         });
-
-    static auto sigRebootPolicy =
-        std::make_unique<sdbusplus::bus::match::match>(
-            *conn,
-            sdbusplus::bus::match::rules::propertiesChanged(
-                "/xyz/openbmc_project/control/host0/auto_reboot",
-                "xyz.openbmc_project.Control.Boot.RebootPolicy"),
-            [this](sdbusplus::message::message& msg) {
-                rebootPolicyStateCallback(msg);
-            });
 }
 
-void SystemStatus::initSystemOperatingParameters()
+void SystemStatus::initSystemOperatingMode()
 {
-    auto retPowerSettings = utils::readBusProperty<std::variant<std::string>>(
-        "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/control/host0/power_restore_policy",
-        "xyz.openbmc_project.Control.Power.RestorePolicy",
-        "PowerRestorePolicy");
+    auto systemOperatingMode = std::get<1>(utils::readSystemParameters());
 
-    if (auto powerSettings = std::get_if<std::string>(&retPowerSettings))
+    if (systemOperatingMode.empty())
     {
-        powerPolicy = *powerSettings;
-    }
-    else
-    {
-        // for error set the parameters for Normal mode value.
-        powerPolicy = "xyz.openbmc_project.Control.Power.RestorePolicy."
-                      "Policy.Restore";
-        std::cerr << "Failed to read power policy from Dbus" << std::endl;
-    }
-
-    auto retRebootSetting = utils::readBusProperty<std::variant<bool>>(
-        "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/control/host0/auto_reboot",
-        "xyz.openbmc_project.Control.Boot.RebootPolicy", "AutoReboot");
-
-    if (auto rebootSettings = std::get_if<bool>(&retRebootSetting))
-    {
-        rebootPolicy = *rebootSettings;
-    }
-    else
-    {
-        // for error set the parameters for Normal mode value.
-        rebootPolicy = true;
-        std::cerr << "Failed t read reboot folicy form Dbus" << std::endl;
-    }
-
-    setSystemCurrentOperatingMode();
-}
-
-void SystemStatus::setSystemCurrentOperatingMode()
-{
-    if (powerPolicy == "xyz.openbmc_project.Control.Power.RestorePolicy.Policy."
-                       "AlwaysOff" &&
-        rebootPolicy == false)
-    {
-        std::cout << "System operating mode set to Manual" << std::endl;
-        stateManager->setSystemOperatingMode("Manual");
-    }
-    else
-    {
-        // if any of the condition fails set mode to normal
-        std::cout << "System operating mode set to Normal as power policy ="
-                  << powerPolicy << " and reboot policy = " << rebootPolicy
+        std::cerr << "System operating mode read as empty from Bios "
+                     "attributes, set as default- Normal"
                   << std::endl;
         stateManager->setSystemOperatingMode("Normal");
+        return;
     }
+
+    stateManager->setSystemOperatingMode(systemOperatingMode);
 }
 } // namespace panel

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -110,41 +110,6 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
     }
 }
 
-void readSystemOperatingMode(std::string& sysOperatingMode)
-{
-    auto readRestorePolicy = readBusProperty<std::variant<std::string>>(
-        "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/control/host0/power_restore_policy",
-        "xyz.openbmc_project.Control.Power.RestorePolicy",
-        "PowerRestorePolicy");
-
-    auto readRebootPolicy = readBusProperty<std::variant<bool>>(
-        "xyz.openbmc_project.Settings",
-        "/xyz/openbmc_project/control/host0/auto_reboot",
-        "xyz.openbmc_project.Control.Boot.RebootPolicy", "AutoReboot");
-
-    const auto restorePolicy = std::get_if<std::string>(&readRestorePolicy);
-    const auto autoRebootPolicy = std::get_if<bool>(&readRebootPolicy);
-
-    if (restorePolicy != nullptr && autoRebootPolicy != nullptr)
-    {
-        if (*restorePolicy == "xyz.openbmc_project.Control.Power."
-                              "RestorePolicy.Policy.AlwaysOff" &&
-            *autoRebootPolicy == false)
-        {
-            sysOperatingMode = "Manual";
-        }
-        else
-        {
-            sysOperatingMode = "Normal";
-        }
-    }
-    else
-    {
-        std::cerr << "Failed to read Bus property" << std::endl;
-    }
-}
-
 types::SystemParameterValues readSystemParameters()
 {
     auto retVal = readBusProperty<std::variant<types::BiosBaseTable>>(
@@ -187,6 +152,10 @@ types::SystemParameterValues readSystemParameters()
                 {
                     hypType = *val;
                 }
+                else if (attributeName == "pvm_system_operating_mode")
+                {
+                    systemOperatingMode = *val;
+                }
             }
         }
     }
@@ -194,8 +163,6 @@ types::SystemParameterValues readSystemParameters()
     {
         std::cerr << "Failed to read BIOS base table" << std::endl;
     }
-
-    readSystemOperatingMode(systemOperatingMode);
 
     return std::make_tuple(OSBootType, systemOperatingMode, HMCManaged,
                            FWIPLType, hypType);


### PR DESCRIPTION
Unlike GUI, Op-panel sets system operating mode based on value of "PowerRestorePolicy" and "RebootPolicy".
To keep the funcytionality in sync, panel code has been modified to update panel state only in case BIOS table has been modified.

Test:
Change system operating mode from GUI, same should be reflected in Panel and vice versa.