### PR TITLE
Expose d-bus method to trigger panel functions

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -70,6 +70,10 @@ class BusHandler
                                [this](const types::FunctionNumber funcNum) {
                                    return this->triggerPanelFunc(funcNum);
                                });
+
+        iface->register_method("getEnabledFunctions", [this]() {
+            return this->getEnabledFunctionsList();
+        });
     }
 
   private:
@@ -131,6 +135,13 @@ class BusHandler
      * @return a tuple with status(true/false) and display lines.
      */
     types::ReturnStatus triggerPanelFunc(const types::FunctionNumber funcNum);
+
+    /**
+     * @brief API to get list of enabled functions.
+     *
+     * @return List of enabled functions.
+     */
+    types::Binary getEnabledFunctionsList();
 };
 
 } // namespace panel

--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -65,6 +65,11 @@ class BusHandler
                                      }
                                      return 0;
                                  });
+
+        iface->register_method("ExecuteFunction",
+                               [this](const types::FunctionNumber funcNum) {
+                                   return this->triggerPanelFunc(funcNum);
+                               });
     }
 
   private:
@@ -116,6 +121,16 @@ class BusHandler
      * @param[in] event: Button event
      */
     void btnRequest(int event);
+
+    /**
+     * @brief API to execute panel function number.
+     *
+     * Method to trigger panel function from external source.
+     *
+     * @param[in] funcNum - Function number to execute
+     * @return a tuple with status(true/false) and display lines.
+     */
+    types::ReturnStatus triggerPanelFunc(const types::FunctionNumber funcNum);
 };
 
 } // namespace panel

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -149,6 +149,18 @@ class Executor
         latestSrcAndHexwords = pelEventId;
     }
 
+    /**
+     * @brief API to execute functions on requests from external source
+     * This method is called whenever there is an external request to trigger a
+     * function.
+     *
+     * @param[in] funcNum - Function number.
+     *
+     * @return status(success/failure, display line 1, display line2)
+     */
+    types::ReturnStatus
+        executeFunctionDirectly(const types::FunctionNumber funcNum);
+
   private:
     /**
      * @brief An api to store event id of last 25 PELs.
@@ -324,5 +336,9 @@ class Executor
     /* SRC and HEX words */
     std::string latestSrcAndHexwords;
 
+    /* To keep track if the execute request is from external or not */
+    bool isExternallyTriggered = false;
+
+    types::ReturnStatus executionStatus = std::make_tuple(false, "", "");
 }; // class Executor
 } // namespace panel

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -136,6 +136,14 @@ class PanelStateManager
      */
     void setCEState();
 
+    /**
+     * @brief API to trigger functions on request from external source
+     * @param[in] funcNum - Function number
+     * @return status of the function
+     */
+    types::ReturnStatus
+        triggerFunctionDirectly(const types::FunctionNumber funcNum);
+
   private:
     /**
      * @brief An Api to set the initial state of PanelState class.
@@ -198,6 +206,13 @@ class PanelStateManager
      * check if any panel function can be enabled/disabled based on that.
      */
     void updateFunctionStatus();
+
+    /**
+     * @brief API which tells if the function is enabled or not
+     * @param[in] funcNum - Function number
+     * @return (true/false) if function is enabled/disabled respectively.
+     */
+    bool isFunctionEnabled(const types::FunctionNumber funcNum);
 
     /**
      * @brief A structure to store information related to a particular

--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -144,6 +144,13 @@ class PanelStateManager
     types::ReturnStatus
         triggerFunctionDirectly(const types::FunctionNumber funcNum);
 
+    /**
+     * @brief API to get list of enabled functions
+     *
+     * @return List of enabled functions
+     */
+    types::Binary getEnabledFunctionsList();
+
   private:
     /**
      * @brief An Api to set the initial state of PanelState class.

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -69,6 +69,8 @@ using InterfacePropertyPair = std::pair<std::string, PropertyValueMap>;
 using singleObjectEntry = std::pair<sdbusplus::message::object_path,
                                     std::vector<InterfacePropertyPair>>;
 
+using ReturnStatus = std::tuple<bool, std::string, std::string>;
+
 /** Get managed objects for Network manager:
  * array{pair(network-object-paths :
  * array{pair(all-interfaces-of-that-obj-path :

--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -88,4 +88,8 @@ types::ReturnStatus
     return (stateManager->triggerFunctionDirectly(funcNum));
 }
 
+types::Binary BusHandler::getEnabledFunctionsList()
+{
+    return (stateManager->getEnabledFunctionsList());
+}
 } // namespace panel

--- a/src/bus_handler.cpp
+++ b/src/bus_handler.cpp
@@ -81,4 +81,11 @@ void BusHandler::btnRequest(int event)
             std::cerr << "Invalid Input" << std::endl;
     }
 }
+
+types::ReturnStatus
+    BusHandler::triggerPanelFunc(const types::FunctionNumber funcNum)
+{
+    return (stateManager->triggerFunctionDirectly(funcNum));
+}
+
 } // namespace panel

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -30,6 +30,13 @@ void Executor::displayExecutionStatus(
     }
 
     convert << (result ? " 00" : " FF");
+
+    if (isExternallyTriggered)
+    {
+        executionStatus = std::make_tuple(result, convert.str(), "");
+        return;
+    }
+
     utils::sendCurrDisplayToPanel(convert.str(), "", transport);
 }
 
@@ -1038,4 +1045,40 @@ void Executor::execute74()
     displayExecutionStatus(74, std::vector<types::FunctionNumber>(), true);
 }
 
+types::ReturnStatus
+    Executor::executeFunctionDirectly(const types::FunctionNumber funcNum)
+{
+    isExternallyTriggered = true;
+    try
+    {
+        switch (funcNum)
+        {
+            case 21:
+            case 22:
+            case 34:
+            case 65:
+            case 66:
+            case 67:
+            case 68:
+            case 69:
+            case 70:
+                sendFuncNumToPhyp(funcNum);
+                break;
+
+            default:
+                std::cerr << "Given function number "
+                          << static_cast<int>(funcNum) << " is not supported."
+                          << std::endl;
+                executionStatus = std::make_tuple(false, "", "");
+        }
+    }
+    catch (std::exception& e)
+    {
+        executionStatus = std::make_tuple(false, "", "");
+        std::cerr << e.what() << std::endl;
+    }
+
+    isExternallyTriggered = false;
+    return executionStatus;
+}
 } // namespace panel

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -1095,6 +1095,33 @@ void PanelStateManager::setCEState()
         }
     }
 }
+
+bool PanelStateManager::isFunctionEnabled(const types::FunctionNumber funcNum)
+{
+    auto pos = find_if(panelFunctions.begin(), panelFunctions.end(),
+                       [funcNum](const PanelFunctionality& afunctionality) {
+                           return afunctionality.functionNumber == funcNum;
+                       });
+    if (pos != panelFunctions.end())
+    {
+        return pos->functionActiveState;
+    }
+
+    return false;
+}
+
+types::ReturnStatus PanelStateManager::triggerFunctionDirectly(
+    const types::FunctionNumber funcNum)
+{
+    if (isFunctionEnabled(funcNum))
+    {
+        return (funcExecutor->executeFunctionDirectly(funcNum));
+    }
+
+    std::cerr << "Function " << static_cast<int>(funcNum) << " is disabled."
+              << std::endl;
+    return std::make_tuple(false, "", "");
+}
 } // namespace manager
 } // namespace state
 } // namespace panel

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -1122,6 +1122,23 @@ types::ReturnStatus PanelStateManager::triggerFunctionDirectly(
               << std::endl;
     return std::make_tuple(false, "", "");
 }
+
+types::Binary PanelStateManager::getEnabledFunctionsList()
+{
+    types::Binary inputFunctions = {21, 22, 34, 65, 66, 67, 68, 69, 70};
+
+    types::Binary enabledFunctions;
+    enabledFunctions.reserve(inputFunctions.size());
+
+    for (auto& val : inputFunctions)
+    {
+        if (isFunctionEnabled(val))
+        {
+            enabledFunctions.push_back(val);
+        }
+    }
+    return enabledFunctions;
+}
 } // namespace manager
 } // namespace state
 } // namespace panel


### PR DESCRIPTION
This commit provides support for a d-bus method to trigger IBMi functions on panel via d-bus call.

The method "TriggerPanelFunction" can be found under "com.ibm.panel" interface which accepts only the function numbers which are IBMi functions.

Supported functions are{21, 22, 34, 65, 66, 67,68, 69, 70}.

Test:
:~# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 30
(bss) false "" ""
  Jul 27 06:11:20 p10bmc pldmd[1768]: 80 02 0a 01 01 00 1b 00 01 00 02 00

:~# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 21
(bss) true "21    00" ""
  Jul 27 06:25:06 p10bmc ibm-panel[1798]: packet data sent to pldm: 80 02 39 08 00 01 01 15

:~# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 22
(bss) true "22    00" ""
 Jul 27 06:26:30 p10bmc ibm-panel[1798]: packet data sent to pldm: 80 02 39 08 00 01 01 16

Change-Id: I2450cfda8341aa7c1546d8fa477a8c8fa35c56f8