### PR TITLE
1020: Display SRC word 0 for terminating SRCs and consider a checkstop a terminating SRC (#182)

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -44,7 +44,7 @@ static constexpr auto locCodeIntf =
 static constexpr auto tmKwdDataLength = 8;
 static constexpr auto ccinDataLength = 4;
 static constexpr auto fiveHexWordsWithSpaces = 44;
-static constexpr auto terminatingBit = 2;
+static constexpr auto terminatingBits = 0xA; // Checkstop and Term due to FW
 
 // Progress code src equivalent to  ascii "00000000"
 static constexpr auto clearDisplayProgressCode = 0x3030303030303030;

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -102,14 +102,14 @@ void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
                         types::Byte byte =
                             ::strtoul(valueAtIndexZero, nullptr, 16);
 
-                        if ((byte & constants::terminatingBit) != 0x00 &&
+                        if ((byte & constants::terminatingBits) != 0x00 &&
                             (hexWords[0][0] == 'B' && hexWords[0][1] == 'D'))
                         {
                             // if terminating bit is set and response
                             // code is for BMC i.e "BD". Send it
                             // directly to display.
                             utils::sendCurrDisplayToPanel(
-                                hexWords.at(4), std::string{}, transport);
+                                hexWords.at(0), std::string{}, transport);
                         }
                         executor->storeLastPelEventId(*eventId);
                         lastPelObjPath = objPath;


### PR DESCRIPTION
#### Display SRC word 0 for terminating SRCs and consider a checkstop a terminating SRC (#182)
```
* Display SRC word 0 for terminating SRCs

The first word of the event ID property contains the 'ASCII string'
field of the SRC which is what should be on the panel.

Tested:
Uncommented the std::cout lines that display what's on the panel and
created a terminating PEL:

Before:
ibm-panel[4105]: L1 : 80000000
ibm-panel[4105]: L2 :

After:
ibm-panel[4127]: L1 : BD70E510
ibm-panel[4127]: L2 :

Signed-off-by: Matt Spinler <spinler@us.ibm.com>

* Also check for checkstop terminating SRC

In the same SRC error status flags byte as the termination due to FW
flag that the code is already checking there is a hardware checkstop
flag. Also check that when looking for terminating SRCs so that checkstop
PELs also make it to the panel.

Tested:
Created a checkstop PEL:
    "Hex Word 5":               "80000000",

Saw it on the panel (uncommented the cout lines):
    ibm-panel[4127]: L1 : BD70E510
    ibm-panel[4127]: L2 :

Checked the other bit still works:
    "Hex Word 5":               "20000000",

    ibm-panel[4127]: L1 : 11002602
    ibm-panel[4127]: L2 :

Signed-off-by: Matt Spinler <spinler@us.ibm.com>

---------

Signed-off-by: Matt Spinler <spinler@us.ibm.com>```