### PR TITLE
fix GCC 13 issues

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -2,6 +2,8 @@
 
 #include "types.hpp"
 
+#include <cstdint>
+
 namespace panel
 {
 namespace constants


### PR DESCRIPTION
GCC 13 removes `uint*_t` family of types from one of the common
includes so we need to explicitly include cstdint.