### PR TITLE
sdbusplus: use shorter type aliases

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -53,7 +53,7 @@ class PanelPresence
     /** @brief Read panel's "Present" property and set the transport key.
      * @param[in] msg - pointer to the msg sent by the PropertiesChanged signal.
      */
-    void readPresentProperty(sdbusplus::message::message& msg);
+    void readPresentProperty(sdbusplus::message_t& msg);
 
     /**
      * @brief Base panel "Present" property callback.
@@ -61,7 +61,7 @@ class PanelPresence
      *
      * @param[in] msg - pointer to the msg sent by the PropertiesChanged signal.
      */
-    void readBasePresentProperty(sdbusplus::message::message& msg);
+    void readBasePresentProperty(sdbusplus::message_t& msg);
 };
 
 /** @class PELListener
@@ -102,10 +102,10 @@ class PELListener
 
   private:
     /* Callback to listen for PEL event log */
-    void PELEventCallBack(sdbusplus::message::message& msg);
+    void PELEventCallBack(sdbusplus::message_t& msg);
 
     /* Callback to listen for PEL Delete event log */
-    void PELDeleteEventCallBack(sdbusplus::message::message& msg);
+    void PELDeleteEventCallBack(sdbusplus::message_t& msg);
 
     /**
      * @brief An Api to set panel function state based on PEL data.
@@ -182,7 +182,7 @@ class BootProgressCode
      * An Api to handle callback in case of progress code property change.
      * @param[in] msg - Callback message.
      */
-    void progressCodeCallBack(sdbusplus::message::message& msg);
+    void progressCodeCallBack(sdbusplus::message_t& msg);
 
     /*Transport Class object */
     std::shared_ptr<Transport> transport;
@@ -246,31 +246,31 @@ class SystemStatus
      * @brief Api to handle BMC state change callback.
      * @param[in] msg - Callback message.
      */
-    void bmcStateCallback(sdbusplus::message::message& msg);
+    void bmcStateCallback(sdbusplus::message_t& msg);
 
     /**
      * @brief Api to handle power state change callback.
      * @param[in] msg - Callback message.
      */
-    void powerStateCallback(sdbusplus::message::message& msg);
+    void powerStateCallback(sdbusplus::message_t& msg);
 
     /**
      * @brief Api to handle boot progress state change callback.
      * @param[in] msg - Callback message.
      */
-    void bootProgressStateCallback(sdbusplus::message::message& msg);
+    void bootProgressStateCallback(sdbusplus::message_t& msg);
 
     /**
      * @brief Api to handle power policy state change callback.
      * @param[in] msg - Callback message.
      */
-    void powerPolicyStateCallback(sdbusplus::message::message& msg);
+    void powerPolicyStateCallback(sdbusplus::message_t& msg);
 
     /**
      * @brief Api to handle reboot policy state change callback.
      * @param[in] msg - Callback message.
      */
-    void rebootPolicyStateCallback(sdbusplus::message::message& msg);
+    void rebootPolicyStateCallback(sdbusplus::message_t& msg);
 
     /**
      * @brief Api to initialize system operating mode.
@@ -287,7 +287,7 @@ class SystemStatus
      *
      * @param[in] msg - Callback message.
      */
-    void biosAttributesCallback(sdbusplus::message::message& msg);
+    void biosAttributesCallback(sdbusplus::message_t& msg);
 
     /* D-Bus connection. */
     std::shared_ptr<sdbusplus::asio::connection> conn;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -81,7 +81,7 @@ void createPEL(const std::string& errIntf, const std::string& sev,
  * @param[in] path -  Dbus object path
  * @param[in] interface - Interface
  */
-std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
+std::string getService(sdbusplus::bus_t& bus, const std::string& path,
                        const std::string& interface);
 
 /** @brief Display on panel using transport class api.

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -57,7 +57,7 @@ static void resetLEDState()
     }
 }
 
-void PanelPresence::readBasePresentProperty(sdbusplus::message::message& msg)
+void PanelPresence::readBasePresentProperty(sdbusplus::message_t& msg)
 {
     if (msg.is_method_error())
     {
@@ -85,7 +85,7 @@ void PanelPresence::readBasePresentProperty(sdbusplus::message::message& msg)
     }
 }
 
-void PanelPresence::readPresentProperty(sdbusplus::message::message& msg)
+void PanelPresence::readPresentProperty(sdbusplus::message_t& msg)
 {
     if (msg.is_method_error())
     {
@@ -137,30 +137,29 @@ void PanelPresence::listenPanelPresence()
     // LEDs.
     if (objectPath == constants::everBaseDbusObj)
     {
-        static std::shared_ptr<sdbusplus::bus::match::match>
-            everBasePanelPresence =
-                std::make_shared<sdbusplus::bus::match::match>(
-                    *conn,
-                    sdbusplus::bus::match::rules::propertiesChanged(
-                        objectPath, constants::itemInterface),
-                    [this](sdbusplus::message::message& msg) {
-                        readBasePresentProperty(msg);
-                    });
-    }
-    else
-    {
-        static std::shared_ptr<sdbusplus::bus::match::match>
-            matchPanelPresence = std::make_shared<sdbusplus::bus::match::match>(
+        static std::shared_ptr<sdbusplus::bus::match_t> everBasePanelPresence =
+            std::make_shared<sdbusplus::bus::match_t>(
                 *conn,
                 sdbusplus::bus::match::rules::propertiesChanged(
                     objectPath, constants::itemInterface),
-                [this](sdbusplus::message::message& msg) {
+                [this](sdbusplus::message_t& msg) {
+                    readBasePresentProperty(msg);
+                });
+    }
+    else
+    {
+        static std::shared_ptr<sdbusplus::bus::match_t> matchPanelPresence =
+            std::make_shared<sdbusplus::bus::match_t>(
+                *conn,
+                sdbusplus::bus::match::rules::propertiesChanged(
+                    objectPath, constants::itemInterface),
+                [this](sdbusplus::message_t& msg) {
                     readPresentProperty(msg);
                 });
     }
 }
 
-void PELListener::PELEventCallBack(sdbusplus::message::message& msg)
+void PELListener::PELEventCallBack(sdbusplus::message_t& msg)
 {
     sdbusplus::message::object_path objPath;
 
@@ -344,25 +343,22 @@ void PELListener::getListOfExistingPels()
 
 void PELListener::listenPelEvents()
 {
-    static auto sigMatch = std::make_unique<sdbusplus::bus::match::match>(
+    static auto sigMatch = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::interfacesAdded(
             "/xyz/openbmc_project/logging"),
-        [this](sdbusplus::message::message& msg) { PELEventCallBack(msg); });
+        [this](sdbusplus::message_t& msg) { PELEventCallBack(msg); });
 
-    static auto infRemovedSigMatch =
-        std::make_unique<sdbusplus::bus::match::match>(
-            *conn,
-            sdbusplus::bus::match::rules::interfacesRemoved(
-                "/xyz/openbmc_project/logging"),
-            [this](sdbusplus::message::message& msg) {
-                PELDeleteEventCallBack(msg);
-            });
+    static auto infRemovedSigMatch = std::make_unique<sdbusplus::bus::match_t>(
+        *conn,
+        sdbusplus::bus::match::rules::interfacesRemoved(
+            "/xyz/openbmc_project/logging"),
+        [this](sdbusplus::message_t& msg) { PELDeleteEventCallBack(msg); });
 
     getListOfExistingPels();
 }
 
-void PELListener::PELDeleteEventCallBack(sdbusplus::message::message& msg)
+void PELListener::PELDeleteEventCallBack(sdbusplus::message_t& msg)
 {
     sdbusplus::message::object_path objPath;
     std::vector<std::string> interface;
@@ -401,17 +397,15 @@ void PELListener::PELDeleteEventCallBack(sdbusplus::message::message& msg)
 void BootProgressCode::listenProgressCode()
 {
     // signal match for sdbusplus
-    static auto sigMatch = std::make_unique<sdbusplus::bus::match::match>(
+    static auto sigMatch = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
             "/xyz/openbmc_project/state/boot/raw0",
             "xyz.openbmc_project.State.Boot.Raw"),
-        [this](sdbusplus::message::message& msg) {
-            progressCodeCallBack(msg);
-        });
+        [this](sdbusplus::message_t& msg) { progressCodeCallBack(msg); });
 }
 
-void BootProgressCode::progressCodeCallBack(sdbusplus::message::message& msg)
+void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
 {
     using PostCode = std::tuple<uint64_t, std::vector<types::Byte>>;
 
@@ -524,7 +518,7 @@ SystemStatus::SystemStatus(
     listenSystemOperatingMode();
 }
 
-void SystemStatus::bmcStateCallback(sdbusplus::message::message& msg)
+void SystemStatus::bmcStateCallback(sdbusplus::message_t& msg)
 {
     std::string object{};
     types::ItemInterfaceMap invItemMap;
@@ -563,14 +557,14 @@ void SystemStatus::listenBmcState()
             "xyz.openbmc_project.State.BMC.BMCState.NotReady");
     }
 
-    static auto sigBmcState = std::make_unique<sdbusplus::bus::match::match>(
+    static auto sigBmcState = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
             "/xyz/openbmc_project/state/bmc0", "xyz.openbmc_project.State.BMC"),
-        [this](sdbusplus::message::message& msg) { bmcStateCallback(msg); });
+        [this](sdbusplus::message_t& msg) { bmcStateCallback(msg); });
 }
 
-void SystemStatus::powerStateCallback(sdbusplus::message::message& msg)
+void SystemStatus::powerStateCallback(sdbusplus::message_t& msg)
 {
     std::string object{};
     types::ItemInterfaceMap invItemMap;
@@ -610,15 +604,15 @@ void SystemStatus::listenPowerState()
             "xyz.openbmc_project.State.Chassis.PowerState.Off");
     }
 
-    static auto sigPowerState = std::make_unique<sdbusplus::bus::match::match>(
+    static auto sigPowerState = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
             "/xyz/openbmc_project/state/chassis0",
             "xyz.openbmc_project.State.Chassis"),
-        [this](sdbusplus::message::message& msg) { powerStateCallback(msg); });
+        [this](sdbusplus::message_t& msg) { powerStateCallback(msg); });
 }
 
-void SystemStatus::bootProgressStateCallback(sdbusplus::message::message& msg)
+void SystemStatus::bootProgressStateCallback(sdbusplus::message_t& msg)
 {
     std::string object{};
     types::ItemInterfaceMap invItemMap;
@@ -660,17 +654,15 @@ void SystemStatus::listenBootProgressState()
             "ProgressStages.Unspecified");
     }
 
-    static auto sigBootState = std::make_unique<sdbusplus::bus::match::match>(
+    static auto sigBootState = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
             "/xyz/openbmc_project/state/host0",
             "xyz.openbmc_project.State.Boot.Progress"),
-        [this](sdbusplus::message::message& msg) {
-            bootProgressStateCallback(msg);
-        });
+        [this](sdbusplus::message_t& msg) { bootProgressStateCallback(msg); });
 }
 
-void SystemStatus::biosAttributesCallback(sdbusplus::message::message& msg)
+void SystemStatus::biosAttributesCallback(sdbusplus::message_t& msg)
 {
     if (msg.is_method_error())
     {
@@ -710,14 +702,12 @@ void SystemStatus::biosAttributesCallback(sdbusplus::message::message& msg)
 
 void SystemStatus::listenSystemOperatingMode()
 {
-    static auto biosMatcher = std::make_unique<sdbusplus::bus::match::match>(
+    static auto biosMatcher = std::make_unique<sdbusplus::bus::match_t>(
         *conn,
         sdbusplus::bus::match::rules::propertiesChanged(
             "/xyz/openbmc_project/bios_config/manager",
             "xyz.openbmc_project.BIOSConfig.Manager"),
-        [this](sdbusplus::message::message& msg) {
-            biosAttributesCallback(msg);
-        });
+        [this](sdbusplus::message_t& msg) { biosAttributesCallback(msg); });
 }
 
 void SystemStatus::initSystemOperatingMode()

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -39,14 +39,14 @@ void createPEL(const std::string& errIntf, const std::string& sev,
         method.append(errIntf, sev, additionalData);
         bus.call(method);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         std::cerr << "Error in invoking D-Bus logging create interface to "
                      "register PEL";
     }
 }
 
-std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
+std::string getService(sdbusplus::bus_t& bus, const std::string& path,
                        const std::string& interface)
 {
     auto mapper = bus.new_method_call(constants::mapperDestination,
@@ -60,7 +60,7 @@ std::string getService(sdbusplus::bus::bus& bus, const std::string& path,
         auto reply = bus.call(mapper);
         reply.read(response);
     }
-    catch (const sdbusplus::exception::exception& e)
+    catch (const sdbusplus::exception_t& e)
     {
         throw std::runtime_error("Service name is not found");
     }


### PR DESCRIPTION
The sdbusplus headers provide shortened aliases for many types.
    Switch to using them to provide better code clarity and shorter
    lines.  Possible replacements are for:
      * bus_t
      * exception_t
      * manager_t
      * match_t
      * message_t
      * object_t
      * slot_t