### PR TITLE
build: upgrade to Meson1.01

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project(
     ],
     license: 'Apache-2.0',
     version: '0.1',
-    meson_version: '>= 0.57',
+    meson_version: '>= 1.0.1',
 )
 
 systemd = dependency('systemd')


### PR DESCRIPTION
Meson 1.0.1 support C++20 and a sufficient portion of the standard has been implemented.  Upgrade the version to leverage it.