### PR TITLE
ExecuteFunction dbus method throws exception

### DIFF
--- a/include/panel_state_manager.hpp
+++ b/include/panel_state_manager.hpp
@@ -222,6 +222,12 @@ class PanelStateManager
     bool isFunctionEnabled(const types::FunctionNumber funcNum);
 
     /**
+     * @brief Check if function is supported to execute from d-bus
+     * @param[in] funcNum - Function number
+     * @return true if function is supported, false otherwise.
+     */
+    bool isFunctionSupported(const types::FunctionNumber funcNum);
+    /**
      * @brief A structure to store information related to a particular
      * functionality. It will carry information like function number, its
      * subrange etc. It will also store active state of a functionality at a

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ project(
 
 systemd = dependency('systemd')
 sdbusplus = dependency('sdbusplus')
+phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
 
 cxx = meson.get_compiler('cpp')
 add_project_arguments(
@@ -79,7 +80,8 @@ executable(
     'src/panel_app_main.cpp',
     dependencies: [
       sdbusplus,
-      dependency('libpldm')
+      dependency('libpldm'),
+      phosphor_dbus_interfaces
     ],
     include_directories: 'include',
     install: true,
@@ -100,7 +102,8 @@ if get_option('tests').enabled()
           sdbusplus,
           gmock,
           gtest,
-          dependency('libpldm')
+          dependency('libpldm'),
+          phosphor_dbus_interfaces
       ],
       include_directories: [
           'include',

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <string_view>
+#include <xyz/openbmc_project/Common/error.hpp>
 
 namespace panel
 {
@@ -1064,18 +1065,14 @@ types::ReturnStatus
             case 70:
                 sendFuncNumToPhyp(funcNum);
                 break;
-
-            default:
-                std::cerr << "Given function number "
-                          << static_cast<int>(funcNum) << " is not supported."
-                          << std::endl;
-                executionStatus = std::make_tuple(false, "", "");
         }
     }
     catch (std::exception& e)
     {
-        executionStatus = std::make_tuple(false, "", "");
-        std::cerr << e.what() << std::endl;
+        isExternallyTriggered = false;
+        std::cerr << "Function " << static_cast<int>(funcNum)
+                  << " execution failed. " << e.what() << std::endl;
+        throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
     }
 
     isExternallyTriggered = false;


### PR DESCRIPTION
This commit is to throw sdbusplus exception when the
dbus-method ExecuteFunction fails to execute.

Possible failure cases are:

-- Function number is disabled -> throw
xyz.openbmc_project.Common.Error.NotAllowed

-- Function execution failed internally -> throw
xyz.openbmc_project.Common.Error.InternalFailure

On successful case:
Method returns a tuple of return code, panel display line1
and panel display line2.

Test:
1. Function is not supported

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 30
Call failed: The operation is not allowed

2. Function is disabled

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 21
Call failed: The operation is not allowed

3. Function internally failed to execute

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel getEnabledFunctions
ay 1 22

systemctl restart pldmd

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 22
Call failed: The operation failed internally.

Log:
Oct 18 08:58:00 rain111bmc ibm-panel[1249]: sd_bus_call: xyz.openbmc_project.Common.Error.ResourceNotFound: The resource is not found.
Oct 18 08:58:00 rain111bmc ibm-panel[1249]: Function 22 execution failed. pldm: Failed to fetch the PDR.

4. Function execution succeeds

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel getEnabledFunctions
ay 1 22

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel ExecuteFunction y 22
(bss) true "22    00" ""

5. Redfish query to getEnabledFunctions

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel getEnabledFunctions
ay 1 22

curl -k -H "X-Auth-Token: $bmc_token" -X GET https://${bmc}/redfish/v1/Systems/system
{
...

"Model": "9105-22B",
  "Name": "system",
  "Oem": {
    "@odata.type": "#OemComputerSystem.Oem",
    "IBM": {
      "@odata.type": "#OemComputerSystem.IBM",
      "EnabledPanelFunctions": [
        22
      ],
      "LampTest": false,
      "PartitionSystemAttentionIndicator": false,
      "PlatformSystemAttentionIndicator": true,
      "SafeMode": false
    }
...
}