### PR TITLE
Update condition get enabled GUI functions

### DIFF
--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -1118,9 +1118,10 @@ bool PanelStateManager::isRemoteAccessEnabled(
                        });
     if (pos != panelFunctions.end())
     {
+        // if the function is enabled by PHYP and system at PHYP runtime.
         return pos->functionEnabledByPhyp &&
                ((systemState & SystemStateMask::ENABLE_PHYP_RUNTIME_STATE) ==
-                0x00);
+                SystemStateMask::ENABLE_PHYP_RUNTIME_STATE);
     }
 
     return false;


### PR DESCRIPTION
Condition to get the list of enabled GUI function has been fixed.

Test:
root@a902be:~# busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel toggleFunctionState ay 9 0 0 96 0 0 2 0 0 66

Mar 16 05:02:13 a902be ibm-panel[6442]:
Bitmap received: 00 00 60 00 00 02 00 00 42
Mar 16 05:02:13 a902be ibm-panel[6442]:  Function enabled: 15 Mar 16 05:02:13 a902be ibm-panel[6442]:  Function enabled: 16 Mar 16 05:02:13 a902be ibm-panel[6442]:  Function enabled: 29 Mar 16 05:02:13 a902be ibm-panel[6442]:  Function enabled: 41 Mar 16 05:02:13 a902be ibm-panel[6442]:  Function enabled: 46

busctl call com.ibm.PanelApp /com/ibm/panel_app com.ibm.panel getEnabledFunctions ay 4 21 22 65 70

Note: Numbers in the logs against function enabled are in hex, corresponding decimal number functions are enabled as shown in the function call to getEnabledFunctions.
Function 41 is not returned as it is not in the list of functions which can be accessed via GUI.