### PR TITLE
API to reboot BMC (#211)

### DIFF
--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -231,6 +231,11 @@ class Executor
     void execute74();
 
     /**
+     * @brief An api to execute function 75.
+     */
+    void execute75();
+
+    /**
      * @brief Api to get PEL eventId.
      *
      * This is a helper function to get the eventId(SRC) data for the PEL

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -153,6 +153,10 @@ void Executor::executeFunction(const types::FunctionNumber funcNumber,
                 execute74();
                 break;
 
+            case 75:
+                execute75();
+                break;
+
             default:
                 break;
         }
@@ -1039,4 +1043,13 @@ void Executor::execute74()
     displayExecutionStatus(74, std::vector<types::FunctionNumber>(), true);
 }
 
+void Executor::execute75()
+{
+    utils::writeBusProperty<std::string>(
+        "xyz.openbmc_project.State.BMC", "/xyz/openbmc_project/state/bmc0",
+        "xyz.openbmc_project.State.BMC", "RequestedBMCTransition",
+        "xyz.openbmc_project.State.BMC.Transition.Reboot");
+
+    utils::sendCurrDisplayToPanel("REBOOTING BMC", " ", transport);
+}
 } // namespace panel

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -159,7 +159,9 @@ std::vector<FunctionalityAttributes> functionalityList = {
     {73, false, true, "A170800B", StateType::INITIAL_STATE,
      (SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_CE_MODE)},
     {74, false, false, "NONE", StateType::INITIAL_STATE,
-     (SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_CE_MODE)}};
+     (SystemStateMask::ENABLE_MANUAL_MODE | SystemStateMask::ENABLE_CE_MODE)},
+    {75, false, true, "A1003075", StateType::INITIAL_STATE,
+     (SystemStateMask::ENABLE_CE_MODE | SystemStateMask::ENABLE_MANUAL_MODE)}};
 
 void PanelStateManager::enableFunctonality(
     const types::FunctionalityList& listOfFunctionalities)


### PR DESCRIPTION
This commit implements function 75 an API to trigger BMC reboot. Function 75 is enabled only when in manual operating mode and CE mode is enabled.

output:
A1003075

Test:
1. After initiating BMC reboot from panel, observed the following logs from the journal phosphor-bmc-state-manager[659]: Setting the RequestedBMCTransition field to xyz.openbmc_project.State.BMC.Transition.Reboot phosphor-bmc-state-manager[659]: Setting the BMCState field to xyz.openbmc_project.State.BMC.BMCState.NotReady

2. Tested by killing the bmcweb process. Killed the bmcweb process. Observed the GUI is frozen and then initiated reboot from panel. After reboot the GUI is back and able to login.

Change-Id: I9f9a1482fbff8cf3ade6c98b6dcdc57bd62b6d36