### PR TITLE
Return success when setting property to same value

### DIFF
--- a/include/bus_handler.hpp
+++ b/include/bus_handler.hpp
@@ -61,9 +61,8 @@ class BusHandler
                                      {
                                          this->executor->setOSIPLMode(newVal);
                                          oldVal = newVal;
-                                         return 1;
                                      }
-                                     return 0;
+                                     return 1;
                                  });
 
         iface->register_method("ExecuteFunction",


### PR DESCRIPTION
Updated set property to always return success, even if the new value is identical to the current value. This ensures that no error is thrown when attempting to set a property to its existing value.

Change-Id: I0c11bb6c39568f4cd9897f6b29378570bcf9c446