### PR TITLE
Update BIOS table type

### DIFF
--- a/include/types.hpp
+++ b/include/types.hpp
@@ -43,7 +43,8 @@ using DbusInterfaceMap = std::map<std::string, PropertyValueMap>;
 using BiosProperty = std::tuple<
     std::string, bool, std::string, std::string, std::string,
     std::variant<int64_t, std::string>, std::variant<int64_t, std::string>,
-    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>>>>;
+    std::vector<std::tuple<std::string, std::variant<int64_t, std::string>,
+                           std::string>>>;
 /*baseBIOSTable reference
 map{attributeName,struct{attributeType,readonlyStatus,displayname,
               description,menuPath,current,default,
@@ -53,7 +54,8 @@ using BiosBaseTableItem = std::pair<std::string, BiosProperty>;
 using BiosBaseTable = std::vector<BiosBaseTableItem>;
 
 using BiosBaseTableType =
-    std::map<std::string, std::variant<std::map<std::string, BiosProperty>>>;
+    std::map<std::string,
+             std::variant<std::monostate, std::map<std::string, BiosProperty>>>;
 
 /* SystemParameterValues reference
  std::tuple<os_ipl_type, system_operating_mode, hmc_managed, fw_boot_side,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,10 +112,11 @@ void sendCurrDisplayToPanel(const std::string& line1, const std::string& line2,
 
 types::SystemParameterValues readSystemParameters()
 {
-    auto retVal = readBusProperty<std::variant<types::BiosBaseTable>>(
-        "xyz.openbmc_project.BIOSConfigManager",
-        "/xyz/openbmc_project/bios_config/manager",
-        "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
+    auto retVal =
+        readBusProperty<std::variant<std::monostate, types::BiosBaseTable>>(
+            "xyz.openbmc_project.BIOSConfigManager",
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
 
     const auto baseBiosTable = std::get_if<types::BiosBaseTable>(&retVal);
 
@@ -161,7 +162,8 @@ types::SystemParameterValues readSystemParameters()
     }
     else
     {
-        std::cerr << "Failed to read BIOS base table" << std::endl;
+        std::cerr << "Failed to read BIOS base table. Invalid type received."
+                  << std::endl;
     }
 
     return std::make_tuple(OSBootType, systemOperatingMode, HMCManaged,


### PR DESCRIPTION
The typedef used for BIOS table needs to be modified to match the changes done in the structure of new BIOS table.
Also, monostate has benn added to the variant received to detect any type change in future.