### PR TITLE
replace system-vpd.service with vpd-manager.service

### DIFF
--- a/service_files/ibm.panel.system.vpd.dependent.service
+++ b/service_files/ibm.panel.system.vpd.dependent.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=IBM operator panel application.
 StopWhenUnneeded=false
-Requires=system-vpd.service
-After=system-vpd.service
+Requires=vpd-manager.service
+After=vpd-manager.service
 Wants=xyz.openbmc_project.Logging.service
 After=xyz.openbmc_project.Logging.service
 


### PR DESCRIPTION
ibm-panel.service depends on system vpd collection which happens in vpd-manager.service as system-vpd.service got deprecated.

Test:
Tested that ibm-panel service starts after vpd-manager service executes. Tested on reset-reload case and also at standby state.