### PR TITLE
Enable SRC functions on progress code events

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -163,10 +163,13 @@ class BootProgressCode
      * @param[in] con - Bus connection.
      * @param[in] execute - pointer to Executor.
      */
-    BootProgressCode(std::shared_ptr<Transport> transport,
-                     std::shared_ptr<sdbusplus::asio::connection> con,
-                     std::shared_ptr<Executor> execute) :
-        transport(transport), conn(con), executor(execute)
+    BootProgressCode(
+        std::shared_ptr<Transport> transport,
+        std::shared_ptr<sdbusplus::asio::connection> con,
+        std::shared_ptr<Executor> execute,
+        std::shared_ptr<state::manager::PanelStateManager> manager) :
+        transport(transport), conn(con), executor(execute),
+        stateManager(manager)
     {
     }
 
@@ -192,6 +195,8 @@ class BootProgressCode
     /* Executor */
     std::shared_ptr<Executor> executor;
 
+    /* State manager */
+    std::shared_ptr<state::manager::PanelStateManager> stateManager;
 }; // class BootProgressCode
 
 /**

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -257,8 +257,8 @@ void PELListener::setPelRelatedFunctionState(
 
     if (!functionStateEnabled)
     {
-        // these functions needs to be enabled only once when first
-        // PEL of desired severity is received.
+        // these functions needs to be enabled only once when first PEL of
+        // desired severity is received.
         functionStateEnabled = true;
         list.emplace_back(11);
         list.emplace_back(12);
@@ -496,6 +496,18 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
                     }
                 }
                 executor->storeSRCAndHexwords(hexWordsWithSRC);
+
+                // Enable functions when progress code is received
+                types::FunctionalityList list;
+                list.reserve(3);
+
+                // these functions needs to be enabled once when progress code
+                // is received
+                list.emplace_back(11);
+                list.emplace_back(12);
+                list.emplace_back(13);
+
+                stateManager->enableFunctonality(list);
             }
         }
         else

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -201,7 +201,8 @@ int main(int, char**)
         pelEvent.listenPelEvents();
 
         // register property change call back for progress code.
-        panel::BootProgressCode progressCode(lcdPanel, conn, executor);
+        panel::BootProgressCode progressCode(lcdPanel, conn, executor,
+                                             stateManager);
         progressCode.listenProgressCode();
 
         panel::BusHandler busHandle(lcdPanel, iface, stateManager, executor);


### PR DESCRIPTION
As functions 11, 12, 13 are to display SRCs & hexwords of any type (say progress SRC/ PEL SRC), whichever SRC event comes first these functions has to be enabled.

In the existing design the functions 11, 12, 13 are enabled only when PEL SRC events are received.

This commit enables the SRC functions 11, 12 and 13 even when progress code events are received by ibm-panel application.

Test:
Tested on P10 rainier to see even if PEL is not found, on occurrence of progress code events, function 11, 12, 13 are enabled.