### PR TITLE
1060:Function 12&13 scrolls off the display

### DIFF
--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -493,6 +493,8 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
                             << static_cast<int>(hexWordArray.at(arrayLoop++));
 
                         hexWordsWithSRC += convert.str();
+                        // clear the buffer
+                        convert.str("");
                     }
                 }
                 executor->storeSRCAndHexwords(hexWordsWithSRC);


### PR DESCRIPTION
This commit fixes the code bug which triggers function 12 and 13 to scroll off the display.

Test:
Before this change, display looks like:
ibm-panel[1079]: L1 : 03031003100003100000
ibm-panel[1079]: L2 :

After this change, display looks like:
ibm-panel[1079]: L1 : 03100000
ibm-panel[1079]: L2 :