### PR TITLE
1050:Function 11,12,13:Conflicting space delimiter (#226)

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -89,5 +89,22 @@ static const types::PICFRUPathMap bootFailPIC = {{rain2s2uIM, systemDbusObj},
                                                  {rain1s4uIM, systemDbusObj},
                                                  {everestIM, everBMCObj},
                                                  {bonnellIM, systemDbusObj}};
+
+static const uint8_t FUNCTION_12 = 12;
+static const uint8_t FUNCTION_13 = 13;
+
+/** PEL SRC data structure has the following sub sections:
+ * 1. 8 byte header.
+ * 2. HEX words each of length 4 bytes.
+ * 3. 32 bytes ascii character string.
+ *
+ * Refer PEL SRC data structure for more details.
+ */
+static const uint8_t FIRST_HEX_WORD_START_OFFSET = 8;
+static const uint8_t LAST_HEX_WORD_START_OFFSET = 36;
+static const uint8_t LEN_OF_RAW_HEX_WORD = 4;
+static const uint8_t WORDS_PER_DISPLAY = 4;
+
+static const std::string defaultHexWordValue = "00000000";
 } // namespace constants
 } // namespace panel

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -314,6 +314,15 @@ class Executor
      */
     void sendFuncNumToPhyp(const types::FunctionNumber& funcNumber);
 
+    /**
+     * @brief API to display SRC functions 12 and 13
+     * This is a common API which can be used to display extended hex SRC words
+     * in function 12 and function 13 on request.
+     *
+     * @param[in] function - Function number (12/13).
+     */
+    void displayHexWords(const uint8_t function);
+
     /*Transport class object*/
     std::shared_ptr<Transport> transport;
 
@@ -338,8 +347,27 @@ class Executor
     /* OS IPL mode state */
     bool osIplMode = false;
 
-    /* SRC and HEX words */
+    /**
+     * Primary SRC and 8 extended hex SRC words are saved in the string
+     * latestSrcAndHexwords. Primary SRC and each extended hex SRC words is of
+     * length 8 bytes. A space is provided as a delimiter between every 8 bytes.
+     */
     std::string latestSrcAndHexwords;
+
+    /** Offsets to find the SRC words stored in the string
+     * latestSrcAndHexwords.*/
+    const uint8_t primarySrcOffset = 0;
+    const uint8_t offsetOfHexWord2 = 9;
+    const uint8_t offsetOfHexWord3 = 18;
+    const uint8_t offsetOfHexWord4 = 27;
+    const uint8_t offsetOfHexWord5 = 36;
+    const uint8_t offsetOfHexWord6 = 45;
+    const uint8_t offsetOfHexWord7 = 54;
+    const uint8_t offsetOfHexWord8 = 63;
+    const uint8_t offsetOfHexWord9 = 72;
+
+    /** Word length */
+    const uint8_t wordLength = 8;
 
     /* To keep track if the execute request is from external or not */
     bool isExternallyTriggered = false;

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -467,60 +467,53 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message::message& msg)
                 return;
             }
 
-            // To detect if there is a need to save SRCs and hexwords in func 11
-            // to 13, check for array data filled with space.
-            if (hexWordArray.at(0) != 0x20)
+            // store the primary SRC.
+            std::string hexWordsWithSRC =
+                std::string(byteArray.begin(), byteArray.end());
+
+            /* Skip first 8 byte header to get the hex word start offset */
+            for (auto hexWordStartOffset =
+                     constants::FIRST_HEX_WORD_START_OFFSET;
+                 hexWordStartOffset <= constants::LAST_HEX_WORD_START_OFFSET;)
             {
-                // store the SRC.
-                std::string hexWordsWithSRC =
-                    std::string(byteArray.begin(), byteArray.end());
-
-                // 4th byte will return number of valid hex words.
-                types::Byte validHexWords = hexWordArray.at(3);
-
-                // Ignoring the first 8 bytes from the array as those are some
-                // header related data not HEX words. Hex words are represented
-                // as 4 bytes so read 4*validHexWords bytes to read all the
-                // hexwords.
                 std::ostringstream convert;
-                for (size_t arrayLoop = 8; arrayLoop <= (4 * validHexWords);)
+
+                // Add a space in between each extended hex SRC word
+                hexWordsWithSRC += " ";
+
+                // Read 4 bytes and convert each byte to hex byte of width 2
+                for (size_t hexWordLoop = 0;
+                     hexWordLoop < constants::LEN_OF_RAW_HEX_WORD;
+                     ++hexWordLoop)
                 {
-                    // clear any previous data.
-                    convert.str("");
-
-                    hexWordsWithSRC += " ";
-
-                    // From this offet read 4 bytes, convert them to HEX and
-                    // then append to final string of hexwords and SRC.
-                    for (size_t hexWordLoop = 0; hexWordLoop < 4; ++hexWordLoop)
-                    {
-                        convert
-                            << std::setfill('0') << std::setw(2) << std::hex
-                            << static_cast<int>(hexWordArray.at(arrayLoop++));
-
-                        hexWordsWithSRC += convert.str();
-                        // clear the buffer
-                        convert.str("");
-                    }
+                    convert << std::setfill('0') << std::setw(2) << std::hex
+                            << static_cast<int>(
+                                   hexWordArray.at(hexWordStartOffset++));
                 }
-                executor->storeSRCAndHexwords(hexWordsWithSRC);
-
-                // Enable functions when progress code is received
-                types::FunctionalityList list;
-                list.reserve(3);
-
-                // these functions needs to be enabled once when progress code
-                // is received
-                list.emplace_back(11);
-                list.emplace_back(12);
-                list.emplace_back(13);
-
-                stateManager->enableFunctonality(list);
+                // Append the 8 byte extended hex SRC word to the string
+                hexWordsWithSRC += convert.str();
             }
+
+            executor->storeSRCAndHexwords(hexWordsWithSRC);
+
+            // Enable functions when progress code is received
+            types::FunctionalityList list;
+            list.reserve(3);
+
+            // these functions needs to be enabled once when progress code
+            // is received
+            list.emplace_back(11);
+            list.emplace_back(12);
+            list.emplace_back(13);
+
+            stateManager->enableFunctonality(list);
         }
         else
         {
-            std::cerr << "Progress code Data error" << std::endl;
+            std::cerr
+                << "Unable to get progress code from "
+                   "xyz.openbmc_project.State.Boot.Raw.Value D-bus property."
+                << std::endl;
         }
     }
 }

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -289,27 +289,17 @@ void Executor::execute20()
 
 void Executor::execute11()
 {
-    if (!latestSrcAndHexwords.empty())
+    if (latestSrcAndHexwords.size() >= wordLength)
     {
-        // find the first space to get response code
-        auto pos = latestSrcAndHexwords.find_first_of(" ");
-
-        // length of src data need to be 8
-        if (pos != std::string::npos && pos == 8)
-        {
-            utils::sendCurrDisplayToPanel((latestSrcAndHexwords).substr(0, pos),
-                                          std::string{}, transport);
-        }
-        else
-        {
-            std::cerr << "Invalid srcData received = " << latestSrcAndHexwords
-                      << std::endl;
-        }
-        return;
+        utils::sendCurrDisplayToPanel(
+            (latestSrcAndHexwords).substr(primarySrcOffset, wordLength),
+            std::string{}, transport);
     }
-
-    // TODO: Decide what needs to be done in this case.
-    std::cerr << "Error getting SRC data" << std::endl;
+    else
+    {
+        std::cerr << "Invalid SRC data received = " << latestSrcAndHexwords
+                  << std::endl;
+    }
 }
 
 static std::string getEthLocPort(const std::string& macAddr)
@@ -560,51 +550,42 @@ void Executor::execute01()
 
 void Executor::execute12()
 {
-    // Need to show blank spaces in case no srcData as function is enabled.
-    constexpr auto blankHexWord = "        ";
-    std::vector<std::string> output(4, blankHexWord);
+    displayHexWords(constants::FUNCTION_12);
+}
+
+void Executor::displayHexWords(const uint8_t function)
+{
+    // Need to show zeroes in case no srcData as function is enabled.
+    std::vector<std::string> output(constants::WORDS_PER_DISPLAY,
+                                    constants::defaultHexWordValue);
 
     if (!latestSrcAndHexwords.empty())
     {
-        std::vector<std::string> src;
-        boost::split(src, latestSrcAndHexwords, boost::is_any_of(" "));
-
-        const auto size = std::min(src.size(), (size_t)5);
-        // ignoring the first hexword as that will be SRC.
-        for (size_t i = 1; i < size; ++i)
+        if (function == constants::FUNCTION_12)
         {
-            output[i - 1] = src[i];
+            output = std::vector<std::string>(
+                {latestSrcAndHexwords.substr(offsetOfHexWord2, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord3, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord4, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord5, wordLength)});
+        }
+        else if (function == constants::FUNCTION_13)
+        {
+            output = std::vector<std::string>(
+                {latestSrcAndHexwords.substr(offsetOfHexWord6, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord7, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord8, wordLength),
+                 latestSrcAndHexwords.substr(offsetOfHexWord9, wordLength)});
         }
     }
 
-    // send blank display if string is empty
     utils::sendCurrDisplayToPanel((output.at(0) + output.at(1)),
                                   (output.at(2) + output.at(3)), transport);
 }
 
 void Executor::execute13()
 {
-    // Need to show blank spaces in case of no hex word as function is
-    // enabled.
-    constexpr auto blankHexWord = "        ";
-    std::vector<std::string> output(4, blankHexWord);
-
-    if (!latestSrcAndHexwords.empty())
-    {
-        std::vector<std::string> src;
-        boost::split(src, latestSrcAndHexwords, boost::is_any_of(" "));
-
-        const auto size = std::min(src.size(), (size_t)9);
-        // ignoring the first five hexword
-        for (size_t i = 5; i < size; ++i)
-        {
-            output[i - 5] = src[i];
-        }
-    }
-
-    // send blank display if string is empty
-    utils::sendCurrDisplayToPanel((output.at(0) + output.at(1)),
-                                  (output.at(2) + output.at(3)), transport);
+    displayHexWords(constants::FUNCTION_13);
 }
 
 void Executor::execute14to19(const types::FunctionNumber funcNumber)


### PR DESCRIPTION
Function 11 is to display primary SRC and function 12 and 13 will display the extended hex src words 2,3,4,5 and 6,7,8,9 respectively.

Existing code uses space as the delimiter to distinguish each SRC words. Where in some cases SRC words itself has a space as one of its values. So having space as a delimiter causes the lcd panel to display incorrect data in function 11, 12 and 13.

Changes made:
Refactored the execute function 11, 12 and 13.
Fixed a defect in progress code saving logic where offset is compared with the number of valid hex words.

Test:

ibm-panel[840]: L1 : 11
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : Linux pp
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 12
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 03100000
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 13
ibm-panel[840]: L2 :

ibm-panel[840]: L1 :
ibm-panel[840]: L2 :