### PR TITLE
1060:Function 11,12,13:Conflicting space delimiter (#226)

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -89,5 +89,22 @@ static const types::PICFRUPathMap bootFailPIC = {{rain2s2uIM, systemDbusObj},
                                                  {rain1s4uIM, systemDbusObj},
                                                  {everestIM, everBMCObj},
                                                  {bonnellIM, systemDbusObj}};
+
+static const uint8_t FUNCTION_12 = 12;
+static const uint8_t FUNCTION_13 = 13;
+
+/** PEL SRC data structure has the following sub sections:
+ * 1. 8 byte header.
+ * 2. HEX words each of length 4 bytes.
+ * 3. 32 bytes ascii character string.
+ *
+ * Refer PEL SRC data structure for more details.
+ */
+static const uint8_t FIRST_HEX_WORD_START_OFFSET = 8;
+static const uint8_t LAST_HEX_WORD_START_OFFSET = 36;
+static const uint8_t LEN_OF_RAW_HEX_WORD = 4;
+static const uint8_t WORDS_PER_DISPLAY = 4;
+
+static const std::string defaultHexWordValue = "00000000";
 } // namespace constants
 } // namespace panel

--- a/include/executor.hpp
+++ b/include/executor.hpp
@@ -314,6 +314,15 @@ class Executor
      */
     void sendFuncNumToPhyp(const types::FunctionNumber& funcNumber);
 
+    /**
+     * @brief API to display SRC functions 12 and 13
+     * This is a common API which can be used to display extended hex SRC words
+     * in function 12 and function 13 on request.
+     *
+     * @param[in] function - Function number (12/13).
+     */
+    void displayHexWords(const uint8_t function);
+
     /*Transport class object*/
     std::shared_ptr<Transport> transport;
 
@@ -338,8 +347,27 @@ class Executor
     /* OS IPL mode state */
     bool osIplMode = false;
 
-    /* SRC and HEX words */
+    /**
+     * Primary SRC and 8 extended hex SRC words are saved in the string
+     * latestSrcAndHexwords. Primary SRC and each extended hex SRC words is of
+     * length 8 bytes. A space is provided as a delimiter between every 8 bytes.
+     */
     std::string latestSrcAndHexwords;
+
+    /** Offsets to find the SRC words stored in the string
+     * latestSrcAndHexwords.*/
+    const uint8_t primarySrcOffset = 0;
+    const uint8_t offsetOfHexWord2 = 9;
+    const uint8_t offsetOfHexWord3 = 18;
+    const uint8_t offsetOfHexWord4 = 27;
+    const uint8_t offsetOfHexWord5 = 36;
+    const uint8_t offsetOfHexWord6 = 45;
+    const uint8_t offsetOfHexWord7 = 54;
+    const uint8_t offsetOfHexWord8 = 63;
+    const uint8_t offsetOfHexWord9 = 72;
+
+    /** Word length */
+    const uint8_t wordLength = 8;
 
     /* To keep track if the execute request is from external or not */
     bool isExternallyTriggered = false;


### PR DESCRIPTION
Function 11 is to display primary SRC and function 12 and 13 will display the extended hex src words 2,3,4,5 and 6,7,8,9 respectively.

Existing code uses space as the delimiter to distinguish each SRC words. Where in some cases SRC words itself has a space as one of its values. So having space as a delimiter causes the lcd panel to display incorrect data in function 11, 12 and 13.

Changes made:
Refactored the execute function 11, 12 and 13.
Fixed a defect in progress code saving logic where offset is compared with the number of valid hex words.

Test:

ibm-panel[840]: L1 : 11
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : Linux pp
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 12
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 03100000
ibm-panel[840]: L2 :

ibm-panel[840]: L1 : 13
ibm-panel[840]: L2 :

ibm-panel[840]: L1 :
ibm-panel[840]: L2 :