### PR TITLE
Change in progress code processing

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -72,7 +72,8 @@ static constexpr auto fiveHexWordsWithSpaces = 44;
 static constexpr auto terminatingBits = 0xA; // Checkstop and Term due to FW
 
 // Progress code src equivalent to  ascii "00000000"
-static constexpr auto clearDisplayProgressCode = 0x3030303030303030;
+static const types::Binary clearDisplayProgressCode = {0x30, 0x30, 0x30, 0x30,
+                                                       0x30, 0x30, 0x30, 0x30};
 static constexpr auto loggerObjectPath = "/xyz/openbmc_project/logging";
 static constexpr auto loggerCreateInterface =
     "xyz.openbmc_project.Logging.Create";

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -407,7 +407,8 @@ void BootProgressCode::listenProgressCode()
 
 void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
 {
-    using PostCode = std::tuple<uint64_t, std::vector<types::Byte>>;
+    using PostCode =
+        std::tuple<std::vector<types::Byte>, std::vector<types::Byte>>;
 
     std::string interface;
     std::map<std::string, std::variant<PostCode>> propertyMap;
@@ -426,6 +427,7 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
             // "00000000"
             if (src == constants::clearDisplayProgressCode)
             {
+                std::cout << "Got clear dispaly progress code" << std::endl;
                 utils::sendCurrDisplayToPanel(std::string{}, std::string{},
                                               transport);
                 // default the display by executing function 01.
@@ -433,21 +435,10 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
                 return;
             }
 
-            std::vector<types::Byte> byteArray;
-            byteArray.reserve(sizeof(src));
+            utils::sendCurrDisplayToPanel(std::string(src.begin(), src.end()),
+                                          std::string{}, transport);
 
-            for (size_t i = 0; i < sizeof(src); i++)
-            {
-                byteArray.emplace_back(types::Byte(src >> (sizeof(src) * i)) &
-                                       0xFF);
-            }
-
-            utils::sendCurrDisplayToPanel(
-                std::string(byteArray.begin(), byteArray.end()), std::string{},
-                transport);
-
-            executor->storeIPLSRC(
-                std::string(byteArray.begin(), byteArray.end()));
+            executor->storeIPLSRC(std::string(src.begin(), src.end()));
 
             // Read the hexwords sent down by Phyp. If the hexwords are present
             // we need to store the SRC to show in function 11 and Hexwords to
@@ -462,8 +453,7 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
             }
 
             // store the primary SRC.
-            std::string hexWordsWithSRC =
-                std::string(byteArray.begin(), byteArray.end());
+            std::string hexWordsWithSRC = std::string(src.begin(), src.end());
 
             /* Skip first 8 byte header to get the hex word start offset */
             for (auto hexWordStartOffset =

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -989,7 +989,8 @@ void PanelStateManager::updatePowerState(const std::string& powerState)
         // As this property is not updated while power off currently, we need to
         // update progress code at poweroff to ASCII 0 so that HMC can clear
         // standby state.
-        utils::writeBusProperty<std::tuple<uint64_t, std::vector<uint8_t>>>(
+        utils::writeBusProperty<
+            std::tuple<std::vector<uint8_t>, std::vector<uint8_t>>>(
             "xyz.openbmc_project.State.Boot.Raw",
             "/xyz/openbmc_project/state/boot/raw0",
             "xyz.openbmc_project.State.Boot.Raw", "Value",


### PR DESCRIPTION
The Value property on the xyz.openbmc_project.State.Boot.Raw interface was changed from uint16_t to array[uint8_t].

Corresponding changes were made in code to process and display progress codes.

Change-Id: I0a84dc72eac5917e72e62dea7fe7782bfebf0109