### PR TITLE
Lcd panel: Fix "device not found" error #729129

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -129,5 +129,7 @@ static const std::string defaultHexWordValue = "00000000";
 
 // Maximum valid instance IDs' which can be created by libpldm
 static constexpr auto PLDM_INST_ID_MAX = 32;
+
+static constexpr auto RETRY_COUNT = 3;
 } // namespace constants
 } // namespace panel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -27,6 +27,12 @@ using PdrList = std::vector<PldmPacket>;
 using PICFRUPathMap = std::unordered_map<std::string, std::string>;
 using PelPathAndSRCList = std::vector<std::pair<std::string, std::string>>;
 
+// map of {"gpio action": {"gpio pin name", pin value}}
+using GpioInfoMap =
+    std::unordered_map<std::string, std::tuple<std::string, uint8_t>>;
+// map of {"IM value": GpioInfoMap}
+using LcdPanelGpioDataMap = std::unordered_map<std::string, GpioInfoMap>;
+
 // map{property::value}
 using PropertyValueMap = std::map<
     std::string,

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -40,6 +40,16 @@ static types::PanelDataMap lcdDataMap = {
      {constants::fujiLcdDevPath, constants::devAddr,
       constants::fujiLcdDbusObj}}};
 
+static const types::GpioInfoMap gpioInfo = {
+    {"gpioPresence", {"RUSSEL_OPPANEL_PRESENCE_N", 0}},
+    {"setGpio", {"RUSSEL_FW_I2C_ENABLE_N", 0}}};
+
+static const std::vector<std::string> systemsNeedsI2cEnableForLcd = {
+    constants::rain2s2uIM,      constants::rain2s4uIM,
+    constants::rain1s4uIM,      constants::balconesIM,
+    constants::blueridge2s2uIM, constants::blueridge2s4uIM,
+    constants::blueridge1s4uIM};
+
 /** @brief Read inventory manager properties from dbus.
  * @param[in] service - Dbus service name
  * @param[in] obj - Dbus object to query for the property.
@@ -260,6 +270,69 @@ void sortPels(types::GetManagedObjects& listOfPels);
  */
 void filterPel(const types::GetManagedObjects& listOfPels,
                types::PelPathAndSRCList& finalListOFPELs);
+
+/**
+ * @brief API to check if device is present.
+ *
+ * This API checks whether the device is present or not by reading device's gpio
+ * presence pin value.
+ *
+ * @param[in] gpioPinName - GPIO pin name.
+ * @param[in] expectedPinState - GPIO pin value to check.
+ * @param[in,out] errorReadingPin -  Flag to set in case of any error occured
+ * while reading the gpio pin.
+ *
+ * @return - Returns true if device is present, false otherwise.
+ */
+bool isDevicePresent(const std::string& gpioPinName,
+                     const uint8_t& expectedPinState,
+                     bool& errorReadingPin) noexcept;
+
+/**
+ * @brief API to set GPIO pin with given value.
+ *
+ * @param gpioPinName[in] - GPIO pin name.
+ * @param pinValue[in] - GPIO pin value.
+ *
+ * @return - Returns true if able to set gpio pin, false otherwise.
+ */
+bool setGpioPin(const std::string& gpioPinName,
+                const uint8_t& pinValue) noexcept;
+
+/**
+ * @brief API to enable gpio access for the given device.
+ *
+ * This API reads the device's gpio presence pin, if found enabled or in case of
+ * any error, will try to set the gpio output pin.
+ *
+ * In case of read or set gpio pin fails, will try to directly read the
+ * microcontroller firmware version, if succeds then it is considered as i2c
+ * access is enabled for the given device.
+ *
+ * @param gpioInfo[in] - Map containing gpio presence and output pin
+ * information.
+ * @param devPath[in] - Device i2c path.
+ * @param devAddress[in] - Device address.
+ *
+ * @return - true if able to access the device, false otherwise.
+ */
+bool enableDeviceI2cAccess(const panel::types::GpioInfoMap& gpioInfo,
+                           const std::string& devPath,
+                           const uint8_t& devAddress) noexcept;
+
+/**
+ * @brief API to check if device is accessible.
+ *
+ * This API checks whether the device is accessible or not by reading the
+ * microcontroller firmware version.
+ *
+ * @param[in] devPath - Device path.
+ * @param[in] devAddress - Device address.
+ *
+ * @return - true if device is accessible, false otherwise.
+ */
+bool isDeviceAccessible(const std::string& devPath,
+                        const uint8_t& devAddress) noexcept;
 
 } // namespace utils
 } // namespace panel

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,11 @@ project(
 systemd = dependency('systemd')
 sdbusplus = dependency('sdbusplus')
 phosphor_dbus_interfaces = dependency('phosphor-dbus-interfaces')
+libgpiodcxx = dependency(
+    'libgpiodcxx',
+    default_options: ['bindings=cxx'],
+    version: '<1.7.0',
+)
 
 cxx = meson.get_compiler('cpp')
 add_project_arguments(
@@ -88,7 +93,12 @@ executable(
 executable(
     'ibm-panel',
     'src/panel_app_main.cpp',
-    dependencies: [sdbusplus, dependency('libpldm'), phosphor_dbus_interfaces],
+    dependencies: [
+        sdbusplus,
+        dependency('libpldm'),
+        phosphor_dbus_interfaces,
+        libgpiodcxx,
+    ],
     include_directories: ['include', 'logger/include'],
     install: true,
     link_with: [panel_app_a, logger],
@@ -108,6 +118,7 @@ if get_option('tests').enabled()
             gtest,
             dependency('libpldm'),
             phosphor_dbus_interfaces,
+            libgpiodcxx,
         ],
         include_directories: ['include'],
         link_with: [panel_app_a],

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -4,6 +4,9 @@
 #include "const.hpp"
 #include "utils.hpp"
 
+#include <unistd.h>
+
+#include <algorithm>
 #include <exception>
 #include <iostream>
 #include <sdbusplus/asio/connection.hpp>
@@ -170,8 +173,22 @@ int main(int, char**)
              * change from false to true; but the transport key is still
              * true(unchanged). To maintain data accuracy get the "Present"
              * property from dbus and set the transport key again.*/
-            lcdPanel->setTransportKey(
-                panel::utils::getLcdPanelPresentProperty(imValue));
+            if (std::find(panel::utils::systemsNeedsI2cEnableForLcd.begin(),
+                          panel::utils::systemsNeedsI2cEnableForLcd.end(),
+                          imValue) !=
+                panel::utils::systemsNeedsI2cEnableForLcd.end())
+            {
+                if (panel::utils::enableDeviceI2cAccess(panel::utils::gpioInfo,
+                                                        lcdDevPath, lcdDevAddr))
+                {
+                    lcdPanel->setTransportKey(true);
+                }
+            }
+            else
+            {
+                lcdPanel->setTransportKey(
+                    panel::utils::getLcdPanelPresentProperty(imValue));
+            }
         }
         else
         {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,13 @@
 #include "i2c_message_encoder.hpp"
 
 #include <libpldm/platform.h>
+#include <linux/i2c-dev.h>
+
+#include <chrono>
+#include <gpiod.hpp>
+#include <thread>
+
+using namespace std::chrono_literals;
 
 namespace panel
 {
@@ -440,6 +447,194 @@ types::PelPathAndSRCList geListOfPELsAndSRCs()
     }
 
     return finalListOfFPELs;
+}
+
+bool isDevicePresent(const std::string& gpioPinName,
+                     const uint8_t& expectedPinState,
+                     bool& errorReadingPin) noexcept
+{
+    if (gpioPinName.empty())
+    {
+        return false;
+    }
+
+    std::string errMsg{};
+    auto retries = constants::RETRY_COUNT;
+
+    while (retries--)
+    {
+        try
+        {
+            gpiod::line l_presenceLine = gpiod::find_line(gpioPinName);
+
+            if (!l_presenceLine)
+            {
+                throw std::runtime_error("Couldn't find the GPIO line.");
+            }
+
+            l_presenceLine.request({"Read the presence line",
+                                    gpiod::line_request::DIRECTION_INPUT, 0});
+
+            errorReadingPin = false;
+            return (l_presenceLine.get_value() == expectedPinState);
+        }
+        catch (const std::exception& ex)
+        {
+            errorReadingPin = true;
+            errMsg = ex.what();
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (errorReadingPin)
+    {
+        std::cerr << "Error occured while checking gpio presence pin value "
+                     "for the pin ["
+                  << gpioPinName << "], expected pin state[" << expectedPinState
+                  << "], error: " << errMsg << std::endl;
+    }
+
+    return true;
+}
+
+bool setGpioPin(const std::string& gpioPinName,
+                const uint8_t& pinValue) noexcept
+{
+    if (gpioPinName.empty())
+    {
+        return false;
+    }
+
+    auto retries = constants::RETRY_COUNT;
+    std::string errMsg{};
+
+    while (retries--)
+    {
+        try
+        {
+            gpiod::line l_outputLine = gpiod::find_line(gpioPinName);
+            if (l_outputLine)
+            {
+                l_outputLine.request({"Panel App Action",
+                                      ::gpiod::line_request::DIRECTION_OUTPUT,
+                                      0},
+                                     pinValue);
+                return true;
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            errMsg = ex.what();
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (!errMsg.empty())
+    {
+        std::cerr << "Error occured while enabling gpio line[" << gpioPinName
+                  << "], error: " << errMsg << std::endl;
+    }
+    return false;
+}
+
+bool isDeviceAccessible(const std::string& devPath,
+                        const uint8_t& devAddress) noexcept
+{
+    int panelFileDescriptor = -1;
+    bool isReadSuccessful = false;
+    try
+    {
+        if ((panelFileDescriptor = open(devPath.data(), O_RDWR | O_NONBLOCK)) ==
+            -1) // open failure
+        {
+            throw std::runtime_error("open system call failed, error code: " +
+                                     std::string(std::strerror(errno)));
+        }
+        if (ioctl(panelFileDescriptor, I2C_SLAVE, devAddress) ==
+            -1) // access failure
+        {
+            throw std::runtime_error("ioctl call failed, error code: " +
+                                     std::string(std::strerror(errno)));
+        }
+
+        panel::types::Binary versionBuffer;
+        constexpr const size_t versionSize = 6;
+        versionBuffer.resize(versionSize);
+
+        auto readSize =
+            ::read(panelFileDescriptor, versionBuffer.data(), versionSize);
+
+        if (versionSize == readSize)
+        {
+            isReadSuccessful = true;
+        }
+        else
+        {
+            std::cerr << "Failed to read device [" << devPath
+                      << "], number of bytes read: " << readSize
+                      << ", errno: " << errno << std::endl;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Failed device access, for the device [" << devPath
+                  << "], address: " << unsigned(devAddress)
+                  << ", error: " << ex.what() << std::endl;
+    }
+
+    if (panelFileDescriptor != -1)
+    {
+        if (close(panelFileDescriptor) == -1)
+        {
+            std::cerr << "close system call failed for the device [" << devPath
+                      << "], with error code: " << std::strerror(errno)
+                      << std::endl;
+        }
+    }
+    return isReadSuccessful;
+}
+
+bool enableDeviceI2cAccess(const panel::types::GpioInfoMap& gpioInfo,
+                           const std::string& devPath,
+                           const uint8_t& devAddress) noexcept
+{
+    try
+    {
+        if (gpioInfo.find("gpioPresence") != gpioInfo.end() &&
+            gpioInfo.find("setGpio") != gpioInfo.end())
+        {
+            bool errorReadingPin = false;
+
+            bool presenceValue = isDevicePresent(
+                std::get<0>(gpioInfo.at("gpioPresence")),
+                std::get<1>(gpioInfo.at("gpioPresence")), errorReadingPin);
+
+            if (presenceValue || errorReadingPin)
+            {
+                bool setGpioSuccess =
+                    setGpioPin(std::get<0>(gpioInfo.at("setGpio")),
+                               std::get<1>(gpioInfo.at("setGpio")));
+                if (setGpioSuccess && !errorReadingPin)
+                {
+                    return true;
+                }
+
+                // Read microcontroller firmware version
+                return isDeviceAccessible(devPath, devAddress);
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr
+            << "Error occured while enabling gpio line for the device path: "
+            << devPath << ", address: " << devAddress << ", error " << ex.what()
+            << std::endl;
+    }
+
+    // Failed to check panel presence
+    return false;
 }
 
 } // namespace utils


### PR DESCRIPTION
The Panel app fails with the error "device not found" after an AC cycle
when it starts before the vpd-manager.

The vpd-manager is responsible for enabling the LCD microcontroller
I2C GPIO pin. When the Panel app starts after vpd-manager, it can
directly access the LCD microcontroller without issues.

However, if the Panel app comes up earlier, the GPIO pin is not yet
enabled, and access to the LCD microcontroller fails.

This change fixes the issue by checking the LCD microcontroller GPIO
presence pin and enabling the I2C GPIO pin before accessing the
microcontroller.