### PR TITLE
Prevent panel crash when IM is not found

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -13,7 +13,6 @@ static constexpr auto baseDevPath = "/dev/i2c-3";
 static constexpr auto balconesBaseDevPath = "/dev/i2c-2";
 static constexpr auto rainLcdDevPath = "/dev/i2c-7";
 static constexpr auto everLcdDevPath = "/dev/i2c-28";
-static constexpr auto tacomaLcdDevPath = "/dev/i2c-0";
 static constexpr auto blueridgeLcdDevPath = "/dev/i2c-7";
 static constexpr auto fujiLcdDevPath = "/dev/i2c-28";
 static constexpr auto balconesLcdDevPath = rainLcdDevPath;

--- a/src/button_handler.cpp
+++ b/src/button_handler.cpp
@@ -55,7 +55,7 @@ ButtonHandler::ButtonHandler(
     }
     else
     {
-        assert("Empty device path");
+        throw std::runtime_error("Device path is empty");
     }
 }
 

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -60,20 +60,16 @@ std::string getInputDevicePath(const std::string& imValue)
         return "/dev/input/by-path/platform-1e78a780.i2c-event-joystick";
     }
 
-    // default to tacoma
-    return "/dev/input/by-path/platform-1e78a080.i2c-bus-event-joystick";
+    return std::string{};
 }
 
 void getLcdDeviceData(std::string& lcdDevPath, uint8_t& lcdDevAddr,
                       std::string& lcdObjPath, const std::string& imValue)
 {
-    if (panel::utils::lcdDataMap.find(imValue) ==
-        panel::utils::lcdDataMap.end()) // assume the system is tacoma
-    {
-        lcdDevPath = panel::constants::tacomaLcdDevPath;
-        lcdDevAddr = panel::constants::devAddr;
-    }
-    else
+    lcdDevAddr = 0;
+
+    if (panel::utils::lcdDataMap.find(imValue) !=
+        panel::utils::lcdDataMap.end())
     {
         lcdDevPath =
             std::get<0>((panel::utils::lcdDataMap.find(imValue))->second);
@@ -81,6 +77,156 @@ void getLcdDeviceData(std::string& lcdDevPath, uint8_t& lcdDevAddr,
             std::get<1>((panel::utils::lcdDataMap.find(imValue))->second);
         lcdObjPath =
             std::get<2>((panel::utils::lcdDataMap.find(imValue))->second);
+    }
+}
+
+/**
+ * @brief Initialize base panel.
+ *
+ * This API creates a Transport object to communicate with the base panel's
+ * I2C device, if valid device details are available for the given IM. It also
+ * creates a listener for the present property change signal from D-Bus for base
+ * panel object path.
+ *
+ * @param[in] imValue - IM keyword value.
+ * @param[in] stateManager - PanelStateManager object.
+ * @param[in] conn - Dbus connection.
+ * @param[in, out] basePanel - Transport object.
+ * @param[out] basePanelPresence - PanelPresence object.
+ *
+ * @throw std::runtime_error, std::bad_alloc
+ */
+void setupBasePanel(
+    const std::string& imValue,
+    const std::shared_ptr<panel::state::manager::PanelStateManager>&
+        stateManager,
+    const auto& conn, std::shared_ptr<panel::Transport>& basePanel,
+    std::unique_ptr<panel::PanelPresence>& basePanelPresence)
+{
+    if (imValue.empty() || !stateManager || !conn)
+    {
+        std::cerr << "Empty input received. Failed to set up transport and "
+                     "presence property listener for the base panel."
+                  << std::endl;
+
+        // ToDo: Check if PEL required
+        return;
+    }
+
+    // listen for panel presence to enable CM on everest.
+    if (baseDataMap.find(imValue) != baseDataMap.end())
+    {
+        basePanel = std::make_shared<panel::Transport>(
+            std::get<0>((baseDataMap.find(imValue))->second),
+            std::get<1>((baseDataMap.find(imValue))->second),
+            panel::types::PanelType::BASE,
+            (panel::constants::bootFailPIC.find(imValue) !=
+             panel::constants::bootFailPIC.end())
+                ? panel::constants::bootFailPIC.find(imValue)->second
+                : std::string());
+
+        auto& baseObjPath = std::get<2>((baseDataMap.find(imValue))->second);
+
+        // if it is base panel of Everest, register for its presence to
+        // enable CM.
+        if (baseObjPath == panel::constants::everBaseDbusObj ||
+            baseObjPath == panel::constants::fujiBaseDbusObj)
+        {
+            basePanelPresence = std::make_unique<panel::PanelPresence>(
+                baseObjPath, conn, basePanel, stateManager);
+
+            basePanelPresence->listenPanelPresence();
+        }
+
+        basePanel->setTransportKey(true);
+    }
+    else
+    {
+        // ToDo: Check if PEL required
+        std::cerr << "Failed to get base panel device details, transport is "
+                     "not created for base panel."
+                  << std::endl;
+    }
+}
+
+/**
+ * @brief Initialize the LCD panel.
+ *
+ * This API creates a listener for the present property change signal from D-Bus
+ * for LCD object path. It also enables transport key based on the device's
+ * presence state.
+ *
+ * @param[in] imValue - IM keyword value.
+ * @param[in] lcdObjPath - Dbus object path.
+ * @param[in] lcdDevPath - LCD i2c device path.
+ * @param[in] lcdDevAddr - LCD i2c device address.
+ * @param[in, out] lcdPanel - Transport object.
+ * @param[in] stateManager - PanelStateManager object.
+ * @param[in] conn - Dbus connection.
+ * @param[out] lcdPanelPresence - PanelPresence object.
+ *
+ * @throw std::runtime_error, std::bad_alloc
+ */
+void setupLcdPanel(
+    const std::string& imValue, std::string& lcdObjPath,
+    const std::string& lcdDevPath, const uint8_t lcdDevAddr,
+    const std::shared_ptr<panel::Transport>& lcdPanel,
+    const std::shared_ptr<panel::state::manager::PanelStateManager>&
+        stateManager,
+    const auto& conn, std::unique_ptr<panel::PanelPresence>& lcdPanelPresence)
+{
+    if (imValue.empty() || lcdObjPath.empty() || lcdDevPath.empty() ||
+        (lcdDevAddr == 0) || !lcdPanel || !stateManager || !conn)
+    {
+        std::cerr
+            << "Empty input received. Transport operations are disabled for "
+               "the LCD device; presence property listener was not created."
+            << std::endl;
+
+        // ToDo: Check if PEL required
+        return;
+    }
+
+    // Listen to lcd panel presence always for both rainier and everest
+    if (panel::utils::lcdDataMap.find(imValue) !=
+        panel::utils::lcdDataMap.end())
+    {
+        lcdPanelPresence = std::make_unique<panel::PanelPresence>(
+            lcdObjPath, conn, lcdPanel, stateManager);
+        lcdPanelPresence->listenPanelPresence();
+
+        /** Race condition can happen when the panel is removed exactly
+         * at the time after setting the transport key(to true - for the
+         * first time) and before firing the match signal. After
+         * removing the panel, "Properties.Changed" signal will wait for
+         * a property change from false to true; but the transport key
+         * is still true(unchanged). To maintain data accuracy get the
+         * "Present" property from dbus and set the transport key
+         * again.*/
+        if (std::find(panel::utils::systemsNeedsI2cEnableForLcd.begin(),
+                      panel::utils::systemsNeedsI2cEnableForLcd.end(),
+                      imValue) !=
+            panel::utils::systemsNeedsI2cEnableForLcd.end())
+        {
+            if (panel::utils::enableDeviceI2cAccess(panel::utils::gpioInfo,
+                                                    lcdDevPath, lcdDevAddr))
+            {
+                lcdPanel->setTransportKey(true);
+            }
+        }
+        else
+        {
+            lcdPanel->setTransportKey(
+                panel::utils::getLcdPanelPresentProperty(imValue));
+        }
+    }
+    else
+    {
+        std::cerr << "Failed to get LCD panel device details, transport "
+                     "operations are disabled for the LCD."
+                  << std::endl;
+
+        // ToDo: Check if PEL required
     }
 }
 
@@ -99,9 +245,30 @@ int main(int, char**)
 
         const std::string imValue = panel::utils::getSystemIM();
 
+        if (imValue.empty())
+        {
+            std::map<std::string, std::string> description{
+                {"DESCRIPTION", "Failed to read IM value from Dbus"}};
+            panel::utils::createPEL(
+                "com.ibm.Panel.Error.DbusError",
+                "xyz.openbmc_project.Logging.Entry.Level.Critical",
+                description);
+
+            // Note: The panel application continues to run even if the IM is
+            // not found for the system. However, LCD and base panel devices
+            // will be unavailable.
+        }
+
         std::string lcdDevPath{}, lcdObjPath{};
         uint8_t lcdDevAddr;
+
         getLcdDeviceData(lcdDevPath, lcdDevAddr, lcdObjPath, imValue);
+
+        // Note: Panel operation will continue its operation even if the LCD
+        // device address is not found. Except communicating to LCD panel,
+        // application can still hold the system sate and exposes the
+        // D-Bus interfaces to outside world to communicate with Panel
+        // application.
 
         // create transport lcd object
         auto lcdPanel = std::make_shared<panel::Transport>(
@@ -115,90 +282,29 @@ int main(int, char**)
             std::make_shared<panel::state::manager::PanelStateManager>(
                 lcdPanel, executor);
 
-        // create transport base object and listen for its presence to
-        // enable CM on everest.
-
         // NOTE:Always base transport key should be set to true prior to LCD
-        // transport key getting set to true. This is to be taken care for code
-        // update scenarios. Reason: If the base panel isn't up, SRC is
-        // displayed on LCD panel. And there needs an external request to LCD
-        // panel to change the display once the base is up. This case can get
-        // avoided by following the panel order to set transport key.
+        // transport key getting set to true. This is to be taken care for
+        // code update scenarios. Reason: If the base panel isn't up, SRC is
+        // displayed on LCD panel. And there needs an external request to
+        // LCD panel to change the display once the base is up. This case
+        // can get avoided by following the panel order to set transport
+        // key.
 
         // create transport base object
         std::shared_ptr<panel::Transport> basePanel;
         std::unique_ptr<panel::PanelPresence> basePanelPresence;
-        if (baseDataMap.find(imValue) != baseDataMap.end())
-        {
-            basePanel = std::make_shared<panel::Transport>(
-                std::get<0>((baseDataMap.find(imValue))->second),
-                std::get<1>((baseDataMap.find(imValue))->second),
-                panel::types::PanelType::BASE,
-                (panel::constants::bootFailPIC.find(imValue) !=
-                 panel::constants::bootFailPIC.end())
-                    ? panel::constants::bootFailPIC.find(imValue)->second
-                    : std::string());
 
-            auto& baseObjPath =
-                std::get<2>((baseDataMap.find(imValue))->second);
+        setupBasePanel(imValue, stateManager, conn, basePanel,
+                       basePanelPresence);
 
-            // if it is base panel of Everest, register for its presence to
-            // enable CM.
-            if (baseObjPath == panel::constants::everBaseDbusObj ||
-                baseObjPath == panel::constants::fujiBaseDbusObj)
-            {
-                basePanelPresence = std::make_unique<panel::PanelPresence>(
-                    baseObjPath, conn, basePanel, stateManager);
+        std::unique_ptr<panel::PanelPresence> lcdPanelPresence;
 
-                basePanelPresence->listenPanelPresence();
-            }
-
-            basePanel->setTransportKey(true);
-        }
-
-        // Listen to lcd panel presence always for both rainier and everest
-        std::unique_ptr<panel::PanelPresence> presence;
-
-        if (panel::utils::lcdDataMap.find(imValue) !=
-            panel::utils::lcdDataMap.end())
-        {
-            presence = std::make_unique<panel::PanelPresence>(
-                lcdObjPath, conn, lcdPanel, stateManager);
-            presence->listenPanelPresence();
-
-            /** Race condition can happen when the panel is removed exactly at
-             * the time after setting the transport key(to true - for the first
-             * time) and before firing the match signal. After removing the
-             * panel, "Properties.Changed" signal will wait for a property
-             * change from false to true; but the transport key is still
-             * true(unchanged). To maintain data accuracy get the "Present"
-             * property from dbus and set the transport key again.*/
-            if (std::find(panel::utils::systemsNeedsI2cEnableForLcd.begin(),
-                          panel::utils::systemsNeedsI2cEnableForLcd.end(),
-                          imValue) !=
-                panel::utils::systemsNeedsI2cEnableForLcd.end())
-            {
-                if (panel::utils::enableDeviceI2cAccess(panel::utils::gpioInfo,
-                                                        lcdDevPath, lcdDevAddr))
-                {
-                    lcdPanel->setTransportKey(true);
-                }
-            }
-            else
-            {
-                lcdPanel->setTransportKey(
-                    panel::utils::getLcdPanelPresentProperty(imValue));
-            }
-        }
-        else
-        {
-            // set transport key to true for test system(tacoma).
-            lcdPanel->setTransportKey(true);
-        }
+        setupLcdPanel(imValue, lcdObjPath, lcdDevPath, lcdDevAddr, lcdPanel,
+                      stateManager, conn, lcdPanelPresence);
 
         // TODO: via https://github.com/ibm-openbmc/ibm-panel/issues/21
-        // Remove this try catch around the button handler once Everest device
-        // tree changes are ready.
+        // Remove this try catch around the button handler once Everest
+        // device tree changes are ready.
         std::unique_ptr<panel::ButtonHandler> btnHandler;
         try
         {
@@ -208,10 +314,9 @@ int main(int, char**)
         }
         catch (const std::runtime_error& e)
         {
-            std::cerr << e.what() << std::endl;
             std::cerr << "Could not initialize button handler, panel buttons "
-                         "will not work!"
-                      << std::endl;
+                         "will not work!, reason: "
+                      << e.what() << std::endl;
         }
 
         panel::PELListener pelEvent(conn, stateManager, executor, lcdPanel);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -21,6 +21,13 @@ namespace panel
 {
 void Transport::panelI2CSetup()
 {
+    if (devPath.empty() || (devAddress == 0))
+    {
+        std::cerr << "Device details are empty; failed to set up I2C for "
+                  << (panelType ? "LCD" : "Base") << " panel." << std::endl;
+        return;
+    }
+
     std::ostringstream byteStream;
     byteStream << "0x" << std::hex << std::uppercase
                << static_cast<int>(devAddress);
@@ -96,6 +103,14 @@ void Transport::panelI2CWrite(const types::Binary& buffer) const
                     failedErrno = errno;
                     sleep(1);
                     const std::string imValue = utils::getSystemIM();
+                    if (imValue.empty())
+                    {
+                        std::cerr << "I2C write failed, as failed to get IM "
+                                     "value from DBus."
+                                  << std::endl;
+                        return;
+                    }
+
                     if (false == utils::getLcdPanelPresentProperty(imValue))
                     {
                         return;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -313,6 +313,13 @@ std::string getSystemIM()
 
 bool getLcdPanelPresentProperty(const std::string& imValue)
 {
+    if (lcdDataMap.find(imValue) == lcdDataMap.end())
+    {
+        std::cerr << "Panel info is missing for the given IM value."
+                  << std::endl;
+        return false;
+    }
+
     auto present = readBusProperty<std::variant<bool>>(
         constants::inventoryManagerIntf,
         std::get<2>((lcdDataMap.find(imValue))->second),


### PR DESCRIPTION
The panel application no longer crashes when the IM value cannot be
retrieved from D-Bus. A critical PEL is logged and the application
continues to run.

When IM is not supported, the panel state manager still maintains
system state and D-Bus APIs remain available for communication.

This commit also removes panel support for the Tacoma system.

Testing:
```
Tested the panel application on the Huygens Simics system, for which panel support
is not yet available.
* A critical PEL is logged for the missing IM.
* Using paneltool, I was able to view the enabled functions on the panel and
successfully change the mode to manual mode using function 2.
* The panel application continued to operate normally.

Tested the same changes on a P10 Rainier system.
* Observed that the LCD panel working correctly.
* LCD buttons were functional and able to execute functions displayed on the screen
without any issues.
```