### PR TITLE
Fix secondary progress code size on power-off

### DIFF
--- a/include/const.hpp
+++ b/include/const.hpp
@@ -130,5 +130,7 @@ static const std::string defaultHexWordValue = "00000000";
 static constexpr auto PLDM_INST_ID_MAX = 32;
 
 static constexpr auto RETRY_COUNT = 3;
+
+static constexpr auto SECONDARY_PROGRESS_CODE_SIZE = 72;
 } // namespace constants
 } // namespace panel

--- a/src/panel_state_manager.cpp
+++ b/src/panel_state_manager.cpp
@@ -994,7 +994,8 @@ void PanelStateManager::updatePowerState(const std::string& powerState)
             "/xyz/openbmc_project/state/boot/raw0",
             "xyz.openbmc_project.State.Boot.Raw", "Value",
             std::make_tuple(constants::clearDisplayProgressCode,
-                            std::vector<uint8_t>{0}));
+                            std::vector<uint8_t>(
+                                constants::SECONDARY_PROGRESS_CODE_SIZE, 0)));
 
         //  default function displayed when we power down.
         funcExecutor->executeFunction(1, types::FunctionalityList{});


### PR DESCRIPTION
This commit updates the code to use fixed-size (72) secondary progress code instead of length 1.
This ensures HMC correctly clears standby state at power-off.

```
Test Result:
root@p11bmc:~# obmcutil state
CurrentBMCState     : xyz.openbmc_project.State.BMC.BMCState.Ready
CurrentPowerState   : xyz.openbmc_project.State.Chassis.PowerState.On
CurrentHostState    : xyz.openbmc_project.State.Host.HostState.Running
BootProgress        : xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified
OperatingSystemState: xyz.openbmc_project.State.OperatingSystem.Status.OSStatus.Inactive

root@p11bmc:~# busctl get-property xyz.openbmc_project.State.Boot.Raw /xyz/openbmc_project/state/boot/raw0 xyz.openbmc_project.State.Boot.Raw Value
(ayay) 8 67 67 48 48 57 49 56 54 72 2 8 0 9 0 0 0 72 0 0 0 224 0 0 0 0 204 0 145 134 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 67 67 48 48 57 49 56 54 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32

root@p11bmc:~# obmcutil state
CurrentBMCState     : xyz.openbmc_project.State.BMC.BMCState.Ready
CurrentPowerState   : xyz.openbmc_project.State.Chassis.PowerState.Off
CurrentHostState    : xyz.openbmc_project.State.Host.HostState.Off
BootProgress        : xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified
OperatingSystemState: xyz.openbmc_project.State.OperatingSystem.Status.OSStatus.Inactive

root@p11bmc:~# busctl get-property xyz.openbmc_project.State.Boot.Raw /xyz/openbmc_project/state/boot/raw0 xyz.openbmc_project.State.Boot.Raw Value
(ayay) 8 48 48 48 48 48 48 48 48 72 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
```