### PR TITLE
Disable SRC functions when progress code is cleared

### DIFF
--- a/include/bus_monitor.hpp
+++ b/include/bus_monitor.hpp
@@ -100,6 +100,24 @@ class PELListener
      */
     void listenPelEvents();
 
+    /**
+     * @brief Disables the function state flag for SRC-related functions.
+     *
+     * Sets the internal functionStateEnabled flag to false, preventing
+     * SRC functions (11–19) from being treated as active. This should
+     * be called when the panel display is cleared (e.g., on receiving
+     * clear progress code) to ensure SRC functions are not
+     * accessible until a new PEL is logged.
+     *
+     * @note This flag is also evaluated by the PEL event listener to
+     *       determine whether SRC functions should be re-enabled on the
+     *       next PEL event.
+     */
+    void DisableFunctionState()
+    {
+        functionStateEnabled = false;
+    }
+
   private:
     /* Callback to listen for PEL event log */
     void PELEventCallBack(sdbusplus::message_t& msg);
@@ -163,13 +181,13 @@ class BootProgressCode
      * @param[in] con - Bus connection.
      * @param[in] execute - pointer to Executor.
      */
-    BootProgressCode(
-        std::shared_ptr<Transport> transport,
-        std::shared_ptr<sdbusplus::asio::connection> con,
-        std::shared_ptr<Executor> execute,
-        std::shared_ptr<state::manager::PanelStateManager> manager) :
+    BootProgressCode(std::shared_ptr<Transport> transport,
+                     std::shared_ptr<sdbusplus::asio::connection> con,
+                     std::shared_ptr<Executor> execute,
+                     std::shared_ptr<state::manager::PanelStateManager> manager,
+                     std::shared_ptr<PELListener> pelListener) :
         transport(transport), conn(con), executor(execute),
-        stateManager(manager)
+        stateManager(manager), pelListener(pelListener)
     {
     }
 
@@ -197,6 +215,8 @@ class BootProgressCode
 
     /* State manager */
     std::shared_ptr<state::manager::PanelStateManager> stateManager;
+
+    std::shared_ptr<PELListener> pelListener;
 }; // class BootProgressCode
 
 /**

--- a/src/bus_monitor.cpp
+++ b/src/bus_monitor.cpp
@@ -426,6 +426,16 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
             // "00000000"
             if (src == constants::clearDisplayProgressCode)
             {
+                std::cout << "Got clear dispaly progress code" << std::endl;
+
+                // Disable function 11 to 19
+                stateManager->disableFunctonality(
+                    {11, 12, 13, 14, 15, 16, 17, 18, 19});
+
+                // as functions are disabled, set the function state flag to
+                // false
+                pelListener->DisableFunctionState();
+
                 utils::sendCurrDisplayToPanel(std::string{}, std::string{},
                                               transport);
                 // default the display by executing function 01.
@@ -489,6 +499,9 @@ void BootProgressCode::progressCodeCallBack(sdbusplus::message_t& msg)
             }
 
             executor->storeSRCAndHexwords(hexWordsWithSRC);
+
+            // Disable functions from 14-19 showing callouts from previous PEL
+            stateManager->disableFunctonality({14, 15, 16, 17, 18, 19});
 
             // Enable functions when progress code is received
             types::FunctionalityList list;

--- a/src/panel_app_main.cpp
+++ b/src/panel_app_main.cpp
@@ -214,12 +214,13 @@ int main(int, char**)
                       << std::endl;
         }
 
-        panel::PELListener pelEvent(conn, stateManager, executor, lcdPanel);
-        pelEvent.listenPelEvents();
+        auto pelEvent = std::make_shared<panel::PELListener>(
+            conn, stateManager, executor, lcdPanel);
+        pelEvent->listenPelEvents();
 
         // register property change call back for progress code.
         panel::BootProgressCode progressCode(lcdPanel, conn, executor,
-                                             stateManager);
+                                             stateManager, pelEvent);
         progressCode.listenProgressCode();
 
         panel::BusHandler busHandle(lcdPanel, iface, stateManager, executor);


### PR DESCRIPTION
Functions 11, 12, 13 were remaining enabled on the panel after the host reached running state because no action was taken when the clear display progress code was received. This caused SRC functions to remain visible without any new PEL is being logged.

The code changes made to fix the above issue by disabling functions 11–19 via the state manager and resetting the PEL listener's functionStateEnabled flag when the zero/clear progress code event is received.

Also disabled functions 14–19 on each new progress code event to clear callout SRCs displayed from the previous PEL.

```
Test:
When Host reaches running state, functions 11, 12, 13 are disabled not show on the panel.

Induced critical PEL, observed that corresponding SRC functions 11-19 are enabled back on the panel.

```